### PR TITLE
update header format

### DIFF
--- a/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/DatabaseAndCollectionCreationAsyncAPITest.java
+++ b/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/DatabaseAndCollectionCreationAsyncAPITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/DocumentCRUDAsyncAPITest.java
+++ b/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/DocumentCRUDAsyncAPITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/DocumentQueryAsyncAPITest.java
+++ b/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/DocumentQueryAsyncAPITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/InMemoryGroupbyTest.java
+++ b/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/InMemoryGroupbyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/TestConfigurations.java
+++ b/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/TestConfigurations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/AccessCondition.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/AccessCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/AccessConditionType.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/AccessConditionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/Attachment.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/Attachment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/BridgeInternal.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/BridgeInternal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/ChangeFeedOptions.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/ChangeFeedOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/Conflict.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/Conflict.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/ConnectionMode.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/ConnectionMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/ConnectionPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/ConnectionPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/ConsistencyLevel.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/ConsistencyLevel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/ConsistencyPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/ConsistencyPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/DataType.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/DataType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/Database.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/Database.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/DatabaseAccount.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/DatabaseAccount.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/DatabaseAccountLocation.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/DatabaseAccountLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/Document.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/Document.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/DocumentClientException.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/DocumentClientException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/DocumentCollection.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/DocumentCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/Error.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/Error.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/ExcludedPath.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/ExcludedPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/FeedOptions.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/FeedOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/FeedOptionsBase.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/FeedOptionsBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/FeedResponse.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/FeedResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/HashIndex.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/HashIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/IncludedPath.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/IncludedPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/Index.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/Index.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/IndexKind.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/IndexKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/IndexingDirective.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/IndexingDirective.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/IndexingMode.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/IndexingMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/IndexingPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/IndexingPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/JsonSerializable.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/JsonSerializable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/MediaOptions.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/MediaOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/MediaReadMode.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/MediaReadMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/MediaResponse.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/MediaResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/Offer.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/Offer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/OfferV2.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/OfferV2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/PartitionKey.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/PartitionKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/PartitionKeyDefinition.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/PartitionKeyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/PartitionKeyRange.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/PartitionKeyRange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/PartitionKind.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/PartitionKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/Permission.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/Permission.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/PermissionMode.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/PermissionMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/RangeIndex.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/RangeIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/ReplicationPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/ReplicationPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/RequestOptions.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/RequestOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/Resource.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/Resource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/ResourceResponse.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/ResourceResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/RetryOptions.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/RetryOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/SerializationFormattingPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/SerializationFormattingPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/SpatialIndex.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/SpatialIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/SqlParameter.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/SqlParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/SqlParameterCollection.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/SqlParameterCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/SqlQuerySpec.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/SqlQuerySpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/StoredProcedure.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/StoredProcedure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/StoredProcedureResponse.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/StoredProcedureResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/Trigger.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/Trigger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/TriggerOperation.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/TriggerOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/TriggerType.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/TriggerType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/Undefined.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/Undefined.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/User.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/User.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/UserDefinedFunction.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/UserDefinedFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/AuthorizationTokenProvider.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/AuthorizationTokenProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/BaseAuthorizationTokenProvider.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/BaseAuthorizationTokenProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/BaseDatabaseAccountConfigurationProvider.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/BaseDatabaseAccountConfigurationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/Constants.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/DatabaseAccountConfigurationProvider.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/DatabaseAccountConfigurationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/EndpointManager.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/EndpointManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/HttpConstants.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/HttpConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/OperationType.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/OperationType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/PathInfo.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/PathInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/PathParser.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/PathParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/Paths.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/Paths.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/PathsHelper.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/PathsHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/QueryCompatibilityMode.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/QueryCompatibilityMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/RequestChargeTracker.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/RequestChargeTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/ResourceId.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/ResourceId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/ResourceType.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/ResourceType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/RetryPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/RetryPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/RuntimeConstants.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/RuntimeConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/SessionContainer.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/SessionContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/SessionTokenHelper.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/SessionTokenHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/UserAgentContainer.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/UserAgentContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/Utils.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/Address.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/Address.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/AddressInformation.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/AddressInformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/StoreResponse.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/StoreResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/WFConstants.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/WFConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/ExceptionHelper.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/ExceptionHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  *

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/ItemComparator.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/ItemComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/ItemType.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/ItemType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/ItemTypeHelper.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/ItemTypeHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/PartitionedQueryExecutionInfo.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/PartitionedQueryExecutionInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/PartitionedQueryExecutionInfoInternal.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/PartitionedQueryExecutionInfoInternal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/QueryInfo.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/QueryInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/SortOrder.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/SortOrder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/aggregation/AggregateOperator.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/aggregation/AggregateOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/aggregation/Aggregator.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/aggregation/Aggregator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/aggregation/AverageAggregator.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/aggregation/AverageAggregator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/aggregation/MaxAggregator.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/aggregation/MaxAggregator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/aggregation/MinAggregator.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/aggregation/MinAggregator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/aggregation/SumAggregator.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/aggregation/SumAggregator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/orderbyquery/OrderByRowResult.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/orderbyquery/OrderByRowResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/orderbyquery/OrderbyRowComparer.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/orderbyquery/OrderbyRowComparer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/BoolPartitionKeyComponent.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/BoolPartitionKeyComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/CollectionRoutingMap.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/CollectionRoutingMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/IPartitionKeyComponent.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/IPartitionKeyComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/InMemoryCollectionRoutingMap.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/InMemoryCollectionRoutingMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/InfinityPartitionKeyComponent.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/InfinityPartitionKeyComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/MaxNumberPartitionKeyComponent.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/MaxNumberPartitionKeyComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/MaxStringPartitionKeyComponent.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/MaxStringPartitionKeyComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/MinNumberPartitionKeyComponent.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/MinNumberPartitionKeyComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/MinStringPartitionKeyComponent.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/MinStringPartitionKeyComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/NullPartitionKeyComponent.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/NullPartitionKeyComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/NumberPartitionKeyComponent.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/NumberPartitionKeyComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/PartitionKeyComponentType.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/PartitionKeyComponentType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/PartitionKeyInternal.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/PartitionKeyInternal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/PartitionKeyRangeIdentity.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/PartitionKeyRangeIdentity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/Range.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/Range.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/RoutingMapProvider.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/RoutingMapProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/RoutingMapProviderHelper.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/RoutingMapProviderHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/StringPartitionKeyComponent.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/StringPartitionKeyComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/UndefinedPartitionKeyComponent.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/UndefinedPartitionKeyComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/AsyncDocumentClient.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/AsyncDocumentClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/AuthorizationTokenType.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/AuthorizationTokenType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/BackoffRetryUtility.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/BackoffRetryUtility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/BadRequestException.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/BadRequestException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ChangeFeedQueryImpl.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ChangeFeedQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ClientRetryPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ClientRetryPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/DatabaseAccountManagerInternal.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/DatabaseAccountManagerInternal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/Exceptions.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/Exceptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/GlobalEndpointManager.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/GlobalEndpointManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IAuthorizationTokenProvider.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IAuthorizationTokenProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ICollectionRoutingMapCache.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ICollectionRoutingMapCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IDocumentClientRetryPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IDocumentClientRetryPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IRetryPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IRetryPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IRetryPolicyFactory.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IRetryPolicyFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IRoutingMapProvider.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IRoutingMapProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/InternalConstants.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/InternalConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/InvalidPartitionException.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/InvalidPartitionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/InvalidPartitionExceptionRetryPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/InvalidPartitionExceptionRetryPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/NotFoundException.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/NotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ObservableHelper.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ObservableHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/PartitionKeyMismatchRetryPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/PartitionKeyMismatchRetryPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/PartitionKeyRangeGoneRetryPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/PartitionKeyRangeGoneRetryPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RMResources.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RMResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ReplicatedResourceClient.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ReplicatedResourceClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ResourceThrottleRetryPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ResourceThrottleRetryPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RetryPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RetryPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RetryUtils.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RetryUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentClientImpl.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentClientImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentServiceRequest.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentServiceRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentServiceResponse.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentServiceResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxGatewayStoreModel.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxGatewayStoreModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxStoreModel.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxStoreModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  *

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/Strings.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/Strings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/Utils.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/AsyncCache.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/AsyncCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  *

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/AsyncLazy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/AsyncLazy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  *

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/IEqualityComparer.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/IEqualityComparer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  *

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/RxClientCollectionCache.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/RxClientCollectionCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/RxCollectionCache.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/RxCollectionCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/RxPartitionKeyRangeCache.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/RxPartitionKeyRangeCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  *

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/AggregateDocumentQueryExecutionContext.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/AggregateDocumentQueryExecutionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/DefaultDocumentQueryExecutionContext.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/DefaultDocumentQueryExecutionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/DocumentProducer.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/DocumentProducer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/DocumentQueryExecutionContextBase.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/DocumentQueryExecutionContextBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/DocumentQueryExecutionContextFactory.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/DocumentQueryExecutionContextFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/IDocumentQueryClient.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/IDocumentQueryClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/IDocumentQueryExecutionComponent.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/IDocumentQueryExecutionComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/IDocumentQueryExecutionContext.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/IDocumentQueryExecutionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/OrderByDocumentQueryExecutionContext.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/OrderByDocumentQueryExecutionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/Paginator.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/Paginator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/ParallelDocumentQueryExecutionContext.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/ParallelDocumentQueryExecutionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/ParallelDocumentQueryExecutionContextBase.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/ParallelDocumentQueryExecutionContextBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/ParallelQueryConfig.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/ParallelQueryConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/PipelinedDocumentQueryExecutionContext.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/PipelinedDocumentQueryExecutionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/ProxyDocumentQueryExecutionContext.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/ProxyDocumentQueryExecutionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/TopDocumentQueryExecutionContext.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/TopDocumentQueryExecutionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/ResourceIdTests.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/ResourceIdTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/StoreResponseTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/StoreResponseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/internal/routing/InMemoryCollectionRoutingMapTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/internal/routing/InMemoryCollectionRoutingMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/internal/routing/RoutingMapProviderHelperTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/internal/routing/RoutingMapProviderHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/AggregateQueryTests.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/AggregateQueryTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/AttachmentCrudTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/AttachmentCrudTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/AttachmentQueryTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/AttachmentQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ChangeFeedTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ChangeFeedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/CollectionCrudTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/CollectionCrudTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/CollectionQueryTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/CollectionQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/DatabaseCrudTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/DatabaseCrudTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/DatabaseQueryTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/DatabaseQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/DocumentCrudTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/DocumentCrudTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/EventLoopSizeTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/EventLoopSizeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/FailureValidator.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/FailureValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/FeedResponseListValidator.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/FeedResponseListValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/FeedResponseValidator.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/FeedResponseValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/OfferQueryTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/OfferQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/OfferReadReplaceTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/OfferReadReplaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/OrderbyDocumentQueryTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/OrderbyDocumentQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  *

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ParallelDocumentQueryTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ParallelDocumentQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  *

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/PermissionCrudTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/PermissionCrudTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/PermissionQueryTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/PermissionQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedAttachmentsTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedAttachmentsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedCollectionsTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedCollectionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  *

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedDatabasesTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedDatabasesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedDocumentsTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedDocumentsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedExceptionHandlingTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedExceptionHandlingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedOffersTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedOffersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  *

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedPermissionsTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedPermissionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedPkrTests.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedPkrTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedStoredProceduresTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedStoredProceduresTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedTriggersTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedTriggersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedUdfsTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedUdfsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedUsersTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ReadFeedUsersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ResourceResponseValidator.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ResourceResponseValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ResourceValidator.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/ResourceValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/SinglePartitionDocumentQueryTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/SinglePartitionDocumentQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/StoredProcedureCrudTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/StoredProcedureCrudTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/StoredProcedureQueryTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/StoredProcedureQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/StoredProcedureUpsertReplaceTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/StoredProcedureUpsertReplaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TestConfigurations.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TestConfigurations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TestSuiteBase.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TestSuiteBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  *

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TopQueryTests.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TopQueryTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TriggerCrudTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TriggerCrudTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TriggerQueryTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TriggerQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TriggerUpsertReplaceTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TriggerUpsertReplaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/UserCrudTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/UserCrudTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/UserDefinedFunctionCrudTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/UserDefinedFunctionCrudTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/UserDefinedFunctionQueryTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/UserDefinedFunctionQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/UserDefinedFunctionUpsertReplaceTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/UserDefinedFunctionUpsertReplaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/UserQueryTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/UserQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/Utils.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/RetryCreateDocumentTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/RetryCreateDocumentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/RetryThrottleTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/RetryThrottleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/SessionTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/SessionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  * 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/caches/AsyncCacheTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/caches/AsyncCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  * Copyright (c) 2018 Microsoft Corporation
  *


### PR DESCRIPTION
Update header file format to use `/* */` instead of `/** */` as the former should be used for the file header format, and the later should be used for javadoc.