### PR TITLE
Update Document Resource getTimestamp for last modified date/time

### DIFF
--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/Resource.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/Resource.java
@@ -133,7 +133,8 @@ public class Resource extends JsonSerializable {
     public Date getTimestamp() {
         Double millisec = super.getDouble(Constants.Properties.LAST_MODIFIED);
         if (millisec == null) return null;
-        return new Date(millisec.longValue());
+        // Multiply the existing 10 digit long value by 1000 to pass to Date. 
+        return new Date(millisec.longValue() * 1000);
     }
 
     /**


### PR DESCRIPTION
Fixing Document getTimestamp() to pass in a 13 digit timestamp long value. Currently this method returns a date from 1970 and the resolution is to pass Date(millisec.longValue() * 1000) instead of Date(millisec.longValue()). 