### PR TITLE
Fix minor javadoc error

### DIFF
--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/RxCollectionCache.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/RxCollectionCache.java
@@ -54,7 +54,7 @@ public abstract class RxCollectionCache {
      * Resolves a request to a collection in a sticky manner.
      * Unless request.ForceNameCacheRefresh is equal to true, it will return the same collection.
      * @param request Request to resolve.
-     * @return an instance of Single<DocumentCollection>
+     * @return an instance of Single&lt;DocumentCollection&gt;
      */
     public Single<DocumentCollection> resolveCollectionAsync(
             RxDocumentServiceRequest request) {


### PR DESCRIPTION
Fix minor javadoc error preventing javadocs from being successfully generated (even though it is internal API)