### PR TITLE
Remove redundant sentences

### DIFF
--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/JsonSerializable.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/JsonSerializable.java
@@ -199,7 +199,7 @@ public class JsonSerializable implements Serializable {
      * @param value        the value of the property.
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public <T extends Object> void set(String propertyName, T value) {
+    public <T> void set(String propertyName, T value) {
         if (value == null) {
             // Sets null.
             this.propertyBag.put(propertyName, JSONObject.NULL);
@@ -363,7 +363,7 @@ public class JsonSerializable implements Serializable {
      *                     and a static one.
      * @return the object value.
      */
-    public <T extends Object> T getObject(String propertyName, Class<T> c) {
+    public <T> T getObject(String propertyName, Class<T> c) {
         if (this.propertyBag.has(propertyName) && !this.propertyBag.isNull(propertyName)) {
             JSONObject jsonObj = this.propertyBag.getJSONObject(propertyName);
             if (Number.class.isAssignableFrom(c) || String.class.isAssignableFrom(c)
@@ -407,7 +407,7 @@ public class JsonSerializable implements Serializable {
      *                     and a static one.
      * @return the object collection.
      */
-    public <T extends Object> Collection<T> getCollection(String propertyName, Class<T> c) {
+    public <T> Collection<T> getCollection(String propertyName, Class<T> c) {
         if (this.propertyBag.has(propertyName) && !this.propertyBag.isNull(propertyName)) {
             JSONArray jsonArray = this.propertyBag.getJSONArray(propertyName);
             Collection<T> result = new ArrayList<T>();
@@ -543,7 +543,7 @@ public class JsonSerializable implements Serializable {
      *            (and not an anonymous or local) and a static one.
      * @return the POJO.
      */
-    public <T extends Object> T toObject(Class<T> c) {
+    public <T> T toObject(Class<T> c) {
         if (JsonSerializable.class.isAssignableFrom(c) || String.class.isAssignableFrom(c)
                 || Number.class.isAssignableFrom(c) || Boolean.class.isAssignableFrom(c)) {
             throw new IllegalArgumentException("c can only be a POJO class or JSONObject");

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/PermissionMode.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/PermissionMode.java
@@ -39,7 +39,7 @@ public enum PermissionMode {
 
     private int value;
 
-    private PermissionMode(int value) {
+    PermissionMode(int value) {
         this.value = value;
     }
 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/SqlParameter.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/SqlParameter.java
@@ -74,7 +74,7 @@ public final class SqlParameter extends JsonSerializable {
      * @param <T>  the type of the parameter
      * @return     the value of the parameter.
      */
-    public <T extends Object> Object getValue(Class<T> c) {
+    public <T> Object getValue(Class<T> c) {
         return super.getObject("value", c);
     }
 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/TriggerOperation.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/TriggerOperation.java
@@ -54,7 +54,7 @@ public enum TriggerOperation {
 
     private int value;
 
-    private TriggerOperation(int value) {
+    TriggerOperation(int value) {
         this.value = value;
     }
 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/TriggerType.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/TriggerType.java
@@ -39,7 +39,7 @@ public enum TriggerType {
 
     private int value;
 
-    private TriggerType(int value) {
+    TriggerType(int value) {
         this.value = value;
     }
 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/EndpointManager.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/EndpointManager.java
@@ -40,14 +40,14 @@ public interface EndpointManager {
      *
      * @return the write endpoint URI
      */
-    public URI getWriteEndpoint();
+    URI getWriteEndpoint();
 
     /**
      * Returns the current read region endpoint.
      *
      * @return the read endpoint URI
      */
-    public URI getReadEndpoint();
+    URI getReadEndpoint();
 
     /**
      * Returns the target endpoint for a given request.
@@ -55,34 +55,34 @@ public interface EndpointManager {
      * @param operationType the operation type
      * @return the service endpoint URI
      */
-    public URI resolveServiceEndpoint(OperationType operationType);
+    URI resolveServiceEndpoint(OperationType operationType);
 
     /**
      * Refreshes the client side endpoint cache.
      */
-    public void refreshEndpointList();
+    void refreshEndpointList();
 
     /**
      * Gets the Database Account resource
      *
      * @return the database account
      */
-    public Observable<DatabaseAccount> getDatabaseAccountFromAnyEndpoint();
+    Observable<DatabaseAccount> getDatabaseAccountFromAnyEndpoint();
 
     /**
      * Mark the current endpoint as unavailable
      */
-    public void markEndpointUnavailable();
+    void markEndpointUnavailable();
 
     /**
      * Close the endpoint manager
      */
-    public void close();
+    void close();
 
     /**
      * Gets a boolean value indicating whether the endpoint manager has been closed.
      *
      * @return true if the endpoint manager has been closed
      */
-    public boolean isClosed();
+    boolean isClosed();
 }

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/ItemType.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/query/ItemType.java
@@ -28,7 +28,7 @@ public enum ItemType {
 
     private final int val;
 
-    private ItemType(int val) {
+    ItemType(int val) {
         this.val = val;
     }
 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/PartitionKeyComponentType.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/internal/routing/PartitionKeyComponentType.java
@@ -38,7 +38,7 @@ enum PartitionKeyComponentType {
 
     private byte value;
 
-    private PartitionKeyComponentType(byte value) {
+    PartitionKeyComponentType(byte value) {
         this.value = value;
     }
 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/DatabaseAccountManagerInternal.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/DatabaseAccountManagerInternal.java
@@ -22,12 +22,11 @@
  */
 package com.microsoft.azure.cosmosdb.rx.internal;
 
-import java.net.URI;
-
 import com.microsoft.azure.cosmosdb.ConnectionPolicy;
 import com.microsoft.azure.cosmosdb.DatabaseAccount;
-
 import rx.Observable;
+
+import java.net.URI;
 
 interface DatabaseAccountManagerInternal {
     
@@ -36,18 +35,18 @@ interface DatabaseAccountManagerInternal {
      * @param endpoint the endpoint from which gets the database account
      * @return the database account.
      */
-    public Observable<DatabaseAccount> getDatabaseAccountFromEndpoint(URI endpoint);
+    Observable<DatabaseAccount> getDatabaseAccountFromEndpoint(URI endpoint);
     
     /**
      * Gets the connection policy
      * @return connection policy
      */
-    public ConnectionPolicy getConnectionPolicy();
+    ConnectionPolicy getConnectionPolicy();
     
     /**
      * Gets the service endpoint
      * @return service endpoint
      */
-    public URI getServiceEndpoint();
+    URI getServiceEndpoint();
 
 }

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ICollectionRoutingMapCache.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ICollectionRoutingMapCache.java
@@ -32,7 +32,7 @@ import rx.Single;
  * This is meant to be internally used only by our sdk.
  **/
 public interface ICollectionRoutingMapCache {
-    public Single<CollectionRoutingMap> tryLookupAsync(
+    Single<CollectionRoutingMap> tryLookupAsync(
             String collectionRid,
             CollectionRoutingMap previousValue);
 }

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IDocumentClientRetryPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IDocumentClientRetryPolicy.java
@@ -44,10 +44,10 @@ public interface IDocumentClientRetryPolicy extends IRetryPolicy {
     /// </remarks>
 
     // TODO: I need to investigate what's the right contract here and/or if/how this is useful
-    public void onBeforeSendRequest(RxDocumentServiceRequest request);
+    void onBeforeSendRequest(RxDocumentServiceRequest request);
 
 
-    public static class NoRetry implements IDocumentClientRetryPolicy {
+    class NoRetry implements IDocumentClientRetryPolicy {
 
         private static NoRetry instance = new NoRetry();
 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IRetryPolicy.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IRetryPolicy.java
@@ -42,9 +42,9 @@ public interface IRetryPolicy  {
     /// <param name="exception">Exception during the callback method invocation</param>
     /// <param name="cancellationToken"></param>
     /// <returns>If the retry needs to be attempted or not</returns>
-    public Single<ShouldRetryResult> shouldRetry(Exception e);
+    Single<ShouldRetryResult> shouldRetry(Exception e);
 
-    public static class ShouldRetryResult {
+    class ShouldRetryResult {
         /// <summary>
         /// How long to wait before next retry. 0 indicates retry immediately.
         /// </summary>

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IRetryPolicyFactory.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/IRetryPolicyFactory.java
@@ -28,5 +28,5 @@ package com.microsoft.azure.cosmosdb.rx.internal;
  */
 public interface IRetryPolicyFactory {
 
-    public IDocumentClientRetryPolicy getRequestPolicy();
+    IDocumentClientRetryPolicy getRequestPolicy();
 }

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/internal/routing/InMemoryCollectionRoutingMapTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/internal/routing/InMemoryCollectionRoutingMapTest.java
@@ -120,7 +120,7 @@ public class InMemoryCollectionRoutingMapTest {
                                 2)),
                         StringUtils.EMPTY);
 
-        assertThat(routingMap).isNull();;
+        assertThat(routingMap).isNull();
 
         routingMap = InMemoryCollectionRoutingMap.tryCreateCompleteRoutingMap(Arrays.asList(
                 new ImmutablePair<PartitionKeyRange, Integer>(new PartitionKeyRange("2", "", "0000000030"), 2),

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/AttachmentCrudTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/AttachmentCrudTest.java
@@ -195,7 +195,7 @@ public class AttachmentCrudTest extends TestSuiteBase {
 
     @BeforeClass(groups = { "simple" }, timeOut = SETUP_TIMEOUT)
     public void beforeClass() {
-        client = clientBuilder.build();;      
+        client = clientBuilder.build();
         Database d = new Database();
         d.setId(DATABASE_ID);
         createdDatabase = safeCreateDatabase(client, d);

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/PermissionCrudTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/PermissionCrudTest.java
@@ -204,7 +204,7 @@ public class PermissionCrudTest extends TestSuiteBase {
     
     @BeforeClass(groups = { "simple" }, timeOut = SETUP_TIMEOUT)
     public void beforeClass() {
-        client = clientBuilder.build();;       
+        client = clientBuilder.build();
         Database d = new Database();
         d.setId(DATABASE_ID);
         createdDatabase = safeCreateDatabase(client, d);

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/PermissionQueryTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/PermissionQueryTest.java
@@ -148,7 +148,7 @@ public class PermissionQueryTest extends TestSuiteBase {
 
     @BeforeClass(groups = { "simple" }, timeOut = SETUP_TIMEOUT)
     public void beforeClass() throws DocumentClientException {
-        client = clientBuilder.build();;       
+        client = clientBuilder.build();
         Database d = new Database();
         d.setId(DATABASE_ID);
         createdDatabase = safeCreateDatabase(client, d);

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/StoredProcedureCrudTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/StoredProcedureCrudTest.java
@@ -114,7 +114,7 @@ public class StoredProcedureCrudTest extends TestSuiteBase {
 
     @BeforeClass(groups = { "simple" }, timeOut = SETUP_TIMEOUT)
     public void beforeClass() {
-        client = clientBuilder.build();;       
+        client = clientBuilder.build();
         Database d = new Database();
         d.setId(DATABASE_ID);
         createdDatabase = safeCreateDatabase(client, d);

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/StoredProcedureUpsertReplaceTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/StoredProcedureUpsertReplaceTest.java
@@ -146,7 +146,7 @@ public class StoredProcedureUpsertReplaceTest extends TestSuiteBase {
 
     @BeforeClass(groups = { "simple" }, timeOut = SETUP_TIMEOUT)
     public void beforeClass() {
-        client = clientBuilder.build();;       
+        client = clientBuilder.build();
         Database d = new Database();
         d.setId(DATABASE_ID);
         createdDatabase = safeCreateDatabase(client, d);

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TriggerCrudTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TriggerCrudTest.java
@@ -124,7 +124,7 @@ public class TriggerCrudTest extends TestSuiteBase {
 
     @BeforeClass(groups = { "simple" }, timeOut = SETUP_TIMEOUT)
     public void beforeClass() {
-        client = clientBuilder.build();;       
+        client = clientBuilder.build();
         Database d = new Database();
         d.setId(DATABASE_ID);
         createdDatabase = safeCreateDatabase(client, d);

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TriggerUpsertReplaceTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TriggerUpsertReplaceTest.java
@@ -133,7 +133,7 @@ public class TriggerUpsertReplaceTest extends TestSuiteBase {
 
     @BeforeClass(groups = { "simple" }, timeOut = SETUP_TIMEOUT)
     public void beforeClass() {
-        client = clientBuilder.build();;       
+        client = clientBuilder.build();
         Database d = new Database();
         d.setId(DATABASE_ID);
         createdDatabase = safeCreateDatabase(client, d);


### PR DESCRIPTION
This PR just remove redundant sentence such as 
¨T extends Object¨ once all objects extend Java that is unnecessary and also a public method in the interface that is defined in the JVM spec.

https://docs.oracle.com/javase/specs/jls/se7/html/jls-9.html#jls-9.4