### PR TITLE
Adds support to Mapper in the SDK

### DIFF
--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/DefaultMapper.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/DefaultMapper.java
@@ -68,7 +68,7 @@ final class DefaultMapper<T> implements Mapper<T> {
 
         String collectionLink = entityMetadata.getCollectionLink();
         Observable<ResourceResponse<Document>> observable = client.upsertDocument(
-                collectionLink, entity, new RequestOptions(), true);
+                collectionLink, entity, new RequestOptions(), entityMetadata.isDisableAutomaticIdGeneration());
         return observable.map(mapperFunction);
     }
 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/DefaultMapper.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/DefaultMapper.java
@@ -61,39 +61,21 @@ final class DefaultMapper<T> implements Mapper<T> {
     }
 
     @Override
-    public Observable<T> create(T entity) {
+    public Observable<T> save(T entity) {
         requireNonNull(entity, "entity is required");
 
 
         String collectionLink = entityMetadata.getCollectionLink();
-        Observable<ResourceResponse<Document>> observable = client.createDocument(
+        Observable<ResourceResponse<Document>> observable = client.upsertDocument(
                 collectionLink, entity, new RequestOptions(), true);
         return observable.map(mapperFunction);
     }
 
     @Override
-    public Observable<List<T>> create(Iterable<T> entities) {
+    public Observable<List<T>> save(Iterable<T> entities) {
         checkNullElements(entities);
 
-        List<Observable<T>> observables = stream(entities.spliterator(), false).map(this::create).collect(toList());
-        return Observable.merge(observables).toList();
-    }
-
-    @Override
-    public Observable<T> update(T entity) {
-        requireNonNull(entity, "entities are required");
-        String collectionLink = entityMetadata.getCollectionLink();
-
-        Observable<ResourceResponse<Document>> observable = client.replaceDocument(
-                collectionLink, entity, new RequestOptions());
-        return observable.map(mapperFunction);
-    }
-
-    @Override
-    public Observable<List<T>> update(Iterable<T> entities) {
-        checkNullElements(entities);
-
-        List<Observable<T>> observables = stream(entities.spliterator(), false).map(this::update).collect(toList());
+        List<Observable<T>> observables = stream(entities.spliterator(), false).map(this::save).collect(toList());
         return Observable.merge(observables).toList();
     }
 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/DefaultMapper.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/DefaultMapper.java
@@ -1,0 +1,170 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmosdb.mapper;
+
+import com.microsoft.azure.cosmosdb.Document;
+import com.microsoft.azure.cosmosdb.FeedOptions;
+import com.microsoft.azure.cosmosdb.FeedResponse;
+import com.microsoft.azure.cosmosdb.RequestOptions;
+import com.microsoft.azure.cosmosdb.ResourceResponse;
+import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
+import rx.Observable;
+import rx.functions.Func1;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
+
+/**
+ * the default implementation of {@link Mapper}
+ * @param <T> the entity type
+ */
+final class DefaultMapper<T> implements Mapper<T> {
+
+    private final Class<T> entityClass;
+
+    private final AsyncDocumentClient client;
+
+    private final EntityMetadata entityMetadata;
+
+    private final Func1<ResourceResponse<Document>, T> mapperFunction;
+
+
+    public DefaultMapper(Class<T> entityClass, AsyncDocumentClient client, EntityMetadata entityMetadata) {
+        this.entityClass = entityClass;
+        this.client = client;
+        this.entityMetadata = entityMetadata;
+        mapperFunction = r -> r.getResource().toObject(entityClass);
+    }
+
+    @Override
+    public Observable<T> create(T entity) {
+        requireNonNull(entity, "entity is required");
+
+
+        String collectionLink = entityMetadata.getCollectionLink();
+        Observable<ResourceResponse<Document>> observable = client.createDocument(
+                collectionLink, entity, new RequestOptions(), true);
+        return observable.map(mapperFunction);
+    }
+
+    @Override
+    public Observable<List<T>> create(Iterable<T> entities) {
+        checkNullElements(entities);
+
+        List<Observable<T>> observables = stream(entities.spliterator(), false).map(this::create).collect(toList());
+        return Observable.merge(observables).toList();
+    }
+
+    @Override
+    public Observable<T> update(T entity) {
+        requireNonNull(entity, "entities are required");
+        String collectionLink = entityMetadata.getCollectionLink();
+
+        Observable<ResourceResponse<Document>> observable = client.replaceDocument(
+                collectionLink, entity, new RequestOptions());
+        return observable.map(mapperFunction);
+    }
+
+    @Override
+    public Observable<List<T>> update(Iterable<T> entities) {
+        checkNullElements(entities);
+
+        List<Observable<T>> observables = stream(entities.spliterator(), false).map(this::update).collect(toList());
+        return Observable.merge(observables).toList();
+    }
+
+
+    @Override
+    public Observable<T> findById(String id) {
+        requireNonNull(id, "id is required");
+
+        return client.readDocument(entityMetadata.getDocumentId(id), null)
+                .map(mapperFunction);
+    }
+
+    @Override
+    public Observable<List<T>> findById(Iterable<String> ids) {
+
+        checkNullIds(ids);
+        List<Observable<T>> observables = stream(ids.spliterator(), false)
+                .map(this::findById)
+                .collect(toList());
+
+        return Observable.merge(observables).toList();
+    }
+
+
+    @Override
+    public Observable<List<T>> query(String query, FeedOptions queryOptions) {
+        requireNonNull(query, "query is required");
+        requireNonNull(queryOptions, "queryOptions is required");
+
+        Observable<FeedResponse<Document>> queryObservable =
+                client.queryDocuments(entityMetadata.getCollectionLink(), query, queryOptions);
+
+        return queryObservable.map(d -> d.getResults().stream()
+                .map(r -> r.toObject(entityClass))
+                .collect(toList()));
+    }
+
+
+    @Override
+    public Observable<Void> deleteById(String id) {
+        requireNonNull(id, "id is required");
+        Observable<ResourceResponse<Document>> observable = client.deleteDocument(entityMetadata.getDocumentId(id), null);
+        return observable.map(d -> null);
+
+
+    }
+
+    @Override
+    public Observable<List<Void>> deleteById(Iterable<String> ids) {
+        checkNullIds(ids);
+
+        List<Observable<Void>> observables = stream(ids.spliterator(), false)
+                .map(this::deleteById)
+                .collect(toList());
+
+        return Observable.merge(observables).toList();
+    }
+
+    private void checkNullIds(Iterable<String> ids) {
+        requireNonNull(ids, "ids is required");
+
+        if (stream(ids.spliterator(), false).anyMatch(Objects::isNull)) {
+            throw new NullPointerException("The elements cannot be null");
+        }
+    }
+
+    private void checkNullElements(Iterable<T> entities) {
+        requireNonNull(entities, "entities are required");
+
+        if (stream(entities.spliterator(), false).anyMatch(Objects::isNull)) {
+            throw new NullPointerException("The elements cannot be null");
+        }
+    }
+}

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/DefaultMappingManager.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/DefaultMappingManager.java
@@ -1,0 +1,146 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmosdb.mapper;
+
+import com.microsoft.azure.cosmosdb.Database;
+import com.microsoft.azure.cosmosdb.DocumentClientException;
+import com.microsoft.azure.cosmosdb.DocumentCollection;
+import com.microsoft.azure.cosmosdb.ResourceResponse;
+import com.microsoft.azure.cosmosdb.SqlParameter;
+import com.microsoft.azure.cosmosdb.SqlParameterCollection;
+import com.microsoft.azure.cosmosdb.SqlQuerySpec;
+import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
+import rx.Observable;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.logging.Logger;
+
+/**
+ * The default implementation of {@link MappingManager}
+ */
+final class DefaultMappingManager implements MappingManager {
+
+    private final AsyncDocumentClient client;
+
+    private static final Logger LOGGER = Logger.getLogger(DefaultMappingManager.class.getName());
+
+    private final Set<String> databases = new TreeSet<>();
+
+    private final Set<EntityMetadata> metadatas = new HashSet<>();
+
+
+    DefaultMappingManager(AsyncDocumentClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public <T> Mapper<T> mapper(Class<T> entityClass) {
+        Objects.requireNonNull(entityClass, "entity class is required");
+        EntityMetadata metadata = EntityMetadata.of(entityClass);
+
+        if (metadatas.contains(metadata)) {
+            LOGGER.info("Entity already checked");
+        } else {
+            metadatas.add(metadata);
+            createDatabase(metadata);
+            createCollection(metadata);
+        }
+        return new DefaultMapper<>(entityClass, client, metadata);
+    }
+
+
+    private void createCollection(EntityMetadata metadata) {
+
+
+        String databaseName = metadata.getDatabaseName();
+        String collectionName = metadata.getCollectionName();
+
+        String databaseLink = metadata.getCollectionLink();
+
+        client.queryCollections(databaseLink,
+                new SqlQuerySpec("SELECT * FROM r where r.id = @id",
+                        new SqlParameterCollection(
+                                new SqlParameter("@id", collectionName))), null)
+                .single()
+                .flatMap(page -> {
+                    if (page.getResults().isEmpty()) {
+                        DocumentCollection collection = new DocumentCollection();
+                        collection.setId(collectionName);
+                        LOGGER.info("Creating collection " + collectionName);
+                        return client.createCollection(databaseLink, collection, null);
+                    } else {
+                        LOGGER.info("Collection " + collectionName + "already exists");
+                        return Observable.empty();
+                    }
+                }).toCompletable().await();
+
+        LOGGER.info("Checking collection " + collectionName + " completed!\n");
+    }
+
+    private void createDatabase(EntityMetadata metadata) {
+
+
+        if (databases.contains(metadata.getDatabaseName())) {
+            LOGGER.info("Database already checked");
+            return;
+        }
+
+        String databaseName = metadata.getDatabaseName();
+        databases.add(databaseName);
+        String databaseLink = String.format("/dbs/%s", databaseName);
+        Observable<ResourceResponse<Database>> databaseReadObs =
+                client.readDatabase(databaseLink, null);
+
+        Observable<ResourceResponse<Database>> databaseExistenceObs =
+                databaseReadObs
+                        .doOnNext(x -> {
+                            System.out.println("database " + databaseName + " already exists.");
+                        })
+                        .onErrorResumeNext(
+                                e -> {
+
+                                    if (e instanceof DocumentClientException) {
+                                        DocumentClientException de = (DocumentClientException) e;
+                                        // if database
+                                        if (de.getStatusCode() == 404) {
+                                            LOGGER.info("database " + databaseName + " doesn't existed, creating it...");
+
+                                            Database dbDefinition = new Database();
+                                            dbDefinition.setId(databaseName);
+
+                                            return client.createDatabase(dbDefinition, null);
+                                        }
+                                    }
+
+                                    LOGGER.info("Reading database " + databaseName + " failed.");
+                                    return Observable.error(e);
+                                });
+
+
+        databaseExistenceObs.toCompletable().await();
+        LOGGER.info("Checking database " + databaseName + " completed!\n");
+    }
+}

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/DefaultMappingManager.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/DefaultMappingManager.java
@@ -32,10 +32,10 @@ import com.microsoft.azure.cosmosdb.SqlQuerySpec;
 import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
 import rx.Observable;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 /**
@@ -47,9 +47,9 @@ final class DefaultMappingManager implements MappingManager {
 
     private static final Logger LOGGER = Logger.getLogger(DefaultMappingManager.class.getName());
 
-    private final Set<String> databases = new TreeSet<>();
+    private final Set<String> databases = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-    private final Set<EntityMetadata> metadatas = new HashSet<>();
+    private final Set<EntityMetadata> metadatas = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
 
     DefaultMappingManager(AsyncDocumentClient client) {
@@ -75,7 +75,6 @@ final class DefaultMappingManager implements MappingManager {
     private void createCollection(EntityMetadata metadata) {
 
 
-        String databaseName = metadata.getDatabaseName();
         String collectionName = metadata.getCollectionName();
 
         String databaseLink = metadata.getCollectionLink();
@@ -110,7 +109,7 @@ final class DefaultMappingManager implements MappingManager {
 
         String databaseName = metadata.getDatabaseName();
         databases.add(databaseName);
-        String databaseLink = String.format("/dbs/%s", databaseName);
+        String databaseLink = metadata.getCollectionLink();
         Observable<ResourceResponse<Database>> databaseReadObs =
                 client.readDatabase(databaseLink, null);
 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/DefaultMappingManager.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/DefaultMappingManager.java
@@ -32,10 +32,7 @@ import com.microsoft.azure.cosmosdb.SqlQuerySpec;
 import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
 import rx.Observable;
 
-import java.util.Collections;
 import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 /**
@@ -47,10 +44,6 @@ final class DefaultMappingManager implements MappingManager {
 
     private static final Logger LOGGER = Logger.getLogger(DefaultMappingManager.class.getName());
 
-    private final Set<String> databases = Collections.newSetFromMap(new ConcurrentHashMap<>());
-
-    private final Set<EntityMetadata> metadatas = Collections.newSetFromMap(new ConcurrentHashMap<>());
-
 
     DefaultMappingManager(AsyncDocumentClient client) {
         this.client = client;
@@ -61,13 +54,8 @@ final class DefaultMappingManager implements MappingManager {
         Objects.requireNonNull(entityClass, "entity class is required");
         EntityMetadata metadata = EntityMetadata.of(entityClass);
 
-        if (metadatas.contains(metadata)) {
-            LOGGER.info("Entity already checked");
-        } else {
-            metadatas.add(metadata);
-            createDatabase(metadata);
-            createCollection(metadata);
-        }
+        createDatabase(metadata);
+        createCollection(metadata);
         return new DefaultMapper<>(entityClass, client, metadata);
     }
 
@@ -102,13 +90,8 @@ final class DefaultMappingManager implements MappingManager {
     private void createDatabase(EntityMetadata metadata) {
 
 
-        if (databases.contains(metadata.getDatabaseName())) {
-            LOGGER.info("Database already checked");
-            return;
-        }
 
         String databaseName = metadata.getDatabaseName();
-        databases.add(databaseName);
         String databaseLink = metadata.getCollectionLink();
         Observable<ResourceResponse<Database>> databaseReadObs =
                 client.readDatabase(databaseLink, null);

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/DefaultMappingManager.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/DefaultMappingManager.java
@@ -65,7 +65,7 @@ final class DefaultMappingManager implements MappingManager {
 
         String collectionName = metadata.getCollectionName();
 
-        String databaseLink = metadata.getCollectionLink();
+        String databaseLink = metadata.getDatabaseLink();
 
         client.queryCollections(databaseLink,
                 new SqlQuerySpec("SELECT * FROM r where r.id = @id",
@@ -79,7 +79,7 @@ final class DefaultMappingManager implements MappingManager {
                         LOGGER.info("Creating collection " + collectionName);
                         return client.createCollection(databaseLink, collection, null);
                     } else {
-                        LOGGER.info("Collection " + collectionName + "already exists");
+                        LOGGER.info("Collection " + collectionName + " already exists");
                         return Observable.empty();
                     }
                 }).toCompletable().await();
@@ -92,7 +92,7 @@ final class DefaultMappingManager implements MappingManager {
 
 
         String databaseName = metadata.getDatabaseName();
-        String databaseLink = metadata.getCollectionLink();
+        String databaseLink = metadata.getDatabaseLink();
         Observable<ResourceResponse<Database>> databaseReadObs =
                 client.readDatabase(databaseLink, null);
 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/Entity.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/Entity.java
@@ -1,0 +1,45 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.azure.cosmosdb.mapper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Entity {
+
+    /**
+     * @return returns the database name to mapping
+     */
+    String databaseName();
+
+    /**
+     * The name of an entity. Defaults to the unqualified name of the entity class.
+     * @return the entity name (Optional)
+     */
+    String collectionName() default "";
+}

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/Entity.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/Entity.java
@@ -39,7 +39,13 @@ public @interface Entity {
 
     /**
      * The name of an entity. Defaults to the unqualified name of the entity class.
+     *
      * @return the entity name (Optional)
      */
     String collectionName() default "";
+
+    /**
+     * @return the flag for disabling automatic id generation.
+     */
+    boolean disableAutomaticIdGeneration() default true;
 }

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadata.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadata.java
@@ -45,6 +45,10 @@ class EntityMetadata {
         return collectionName;
     }
 
+    public String getDatabaseLink() {
+        return String.format("/dbs/%s", databaseName);
+    }
+
     public String getCollectionLink() {
         return String.format("/dbs/%s/colls/%s", databaseName, collectionName);
     }

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadata.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadata.java
@@ -1,0 +1,91 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmosdb.mapper;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Objects;
+
+class EntityMetadata {
+
+    private final String databaseName;
+
+    private final String collectionName;
+
+    EntityMetadata(String databaseName, String collectionName) {
+        this.databaseName = databaseName;
+        this.collectionName = collectionName;
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public String getCollectionName() {
+        return collectionName;
+    }
+
+    public String getCollectionLink() {
+        return String.format("/dbs/%s/colls/%s", databaseName, collectionName);
+    }
+
+    public String getDocumentId(String id) {
+        return String.format("/dbs/%s/colls/%s/docs/%s", databaseName, collectionName, id);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof EntityMetadata)) {
+            return false;
+        }
+        EntityMetadata that = (EntityMetadata) o;
+        return Objects.equals(databaseName, that.databaseName) &&
+                Objects.equals(collectionName, that.collectionName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(databaseName, collectionName);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("EntityMetadata{");
+        sb.append("databaseName='").append(databaseName).append('\'');
+        sb.append(", collectionName='").append(collectionName).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    public static <T> EntityMetadata of(Class<T> entityClass) {
+        Entity entity = entityClass.getAnnotation(Entity.class);
+        String databaseName = entity.databaseName();
+        String collectionName = StringUtils.isBlank(entity.collectionName()) ? entityClass.getSimpleName()
+                : entity.collectionName();
+        return new EntityMetadata(databaseName, collectionName);
+    }
+
+}

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadata.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadata.java
@@ -22,9 +22,9 @@
  */
 package com.microsoft.azure.cosmosdb.mapper;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.Objects;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 class EntityMetadata {
 
@@ -81,9 +81,18 @@ class EntityMetadata {
     }
 
     public static <T> EntityMetadata of(Class<T> entityClass) {
+
         Entity entity = entityClass.getAnnotation(Entity.class);
+
+        if(entity == null) {
+            throw new IllegalArgumentException("The annotation com.microsoft.azure.cosmosdb.mapper.Entity is required at this class: " + entityClass);
+        }
+
+        if(isBlank(entity.databaseName())) {
+            throw new IllegalArgumentException("The database field cannot be null at @Entity in the class: " + entityClass);
+        }
         String databaseName = entity.databaseName();
-        String collectionName = StringUtils.isBlank(entity.collectionName()) ? entityClass.getSimpleName()
+        String collectionName = isBlank(entity.collectionName()) ? entityClass.getSimpleName()
                 : entity.collectionName();
         return new EntityMetadata(databaseName, collectionName);
     }

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadata.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadata.java
@@ -22,8 +22,6 @@
  */
 package com.microsoft.azure.cosmosdb.mapper;
 
-import java.util.Objects;
-
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 class EntityMetadata {
@@ -57,32 +55,6 @@ class EntityMetadata {
         return String.format("/dbs/%s/colls/%s/docs/%s", databaseName, collectionName, id);
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof EntityMetadata)) {
-            return false;
-        }
-        EntityMetadata that = (EntityMetadata) o;
-        return Objects.equals(databaseName, that.databaseName) &&
-                Objects.equals(collectionName, that.collectionName);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(databaseName, collectionName);
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("EntityMetadata{");
-        sb.append("databaseName='").append(databaseName).append('\'');
-        sb.append(", collectionName='").append(collectionName).append('\'');
-        sb.append('}');
-        return sb.toString();
-    }
 
     public static <T> EntityMetadata of(Class<T> entityClass) {
 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadata.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadata.java
@@ -30,9 +30,12 @@ class EntityMetadata {
 
     private final String collectionName;
 
-    EntityMetadata(String databaseName, String collectionName) {
+    private final boolean disableAutomaticIdGeneration;
+
+    EntityMetadata(String databaseName, String collectionName, boolean disableAutomaticIdGeneration) {
         this.databaseName = databaseName;
         this.collectionName = collectionName;
+        this.disableAutomaticIdGeneration = disableAutomaticIdGeneration;
     }
 
     public String getDatabaseName() {
@@ -49,6 +52,10 @@ class EntityMetadata {
 
     public String getCollectionLink() {
         return String.format("/dbs/%s/colls/%s", databaseName, collectionName);
+    }
+
+    public boolean isDisableAutomaticIdGeneration() {
+        return disableAutomaticIdGeneration;
     }
 
     public String getDocumentId(String id) {
@@ -70,7 +77,7 @@ class EntityMetadata {
         String databaseName = entity.databaseName();
         String collectionName = isBlank(entity.collectionName()) ? entityClass.getSimpleName()
                 : entity.collectionName();
-        return new EntityMetadata(databaseName, collectionName);
+        return new EntityMetadata(databaseName, collectionName, entity.disableAutomaticIdGeneration());
     }
 
 }

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadata.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadata.java
@@ -63,16 +63,18 @@ class EntityMetadata {
     }
 
 
-    public static <T> EntityMetadata of(Class<T> entityClass) {
+    static <T> EntityMetadata of(Class<T> entityClass) {
 
         Entity entity = entityClass.getAnnotation(Entity.class);
 
-        if(entity == null) {
-            throw new IllegalArgumentException("The annotation com.microsoft.azure.cosmosdb.mapper.Entity is required at this class: " + entityClass);
+        if (entity == null) {
+            throw new IllegalArgumentException("The annotation " + Entity.class.getName()
+                    + " is required at this class: " + entityClass);
         }
 
-        if(isBlank(entity.databaseName())) {
-            throw new IllegalArgumentException("The database field cannot be null at @Entity in the class: " + entityClass);
+        if (isBlank(entity.databaseName())) {
+            throw new IllegalArgumentException("The database field cannot be null at @Entity in the class: "
+                    + entityClass);
         }
         String databaseName = entity.databaseName();
         String collectionName = isBlank(entity.collectionName()) ? entityClass.getSimpleName()

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/Mapper.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/Mapper.java
@@ -37,41 +37,22 @@ import java.util.List;
 public interface Mapper<T> {
 
     /**
-     * Creates an entity.
+     * Saves an entity.
      *
      * @param entity the entity to be created in the database
      * @return an {@link Observable} containing the single resource response with the created document or an error.
      * @throws NullPointerException when entity is null
      */
-    Observable<T> create(T entity);
+    Observable<T> save(T entity);
 
     /**
-     * Creates entities in database.
+     * Saves entities in database.
      *
      * @param entities the entities to be created in the database
      * @return an {@link Observable} containing the merged resource response with the created document or an error.
      * @throws NullPointerException when either entities is null or there is any null element
      */
-    Observable<List<T>> create(Iterable<T> entities);
-
-    /**
-     * Updates an entity using {@link AsyncDocumentClient#replaceDocument(String, Object, RequestOptions)}
-     *
-     * @param entity the entity to be updated in the database
-     * @return an {@link Observable} containing the single resource response with the created document or an error.
-     * @throws NullPointerException when entity is null
-     */
-    Observable<T> update(T entity);
-
-    /**
-     * Updates an entity using {@link AsyncDocumentClient#replaceDocument(String, Object, RequestOptions)}
-     * then merge the result
-     *
-     * @param entities the entities to be updated in the database
-     * @return an {@link Observable} containing the merged resource response with the created document or an error.
-     * @throws NullPointerException when either entities is null or there is any null element
-     */
-    Observable<List<T>> update(Iterable<T> entities);
+    Observable<List<T>> save(Iterable<T> entities);
 
     /**
      * Finds entity by id

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/Mapper.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/Mapper.java
@@ -24,6 +24,7 @@ package com.microsoft.azure.cosmosdb.mapper;
 
 import com.microsoft.azure.cosmosdb.FeedOptions;
 import com.microsoft.azure.cosmosdb.RequestOptions;
+import com.microsoft.azure.cosmosdb.SqlQuerySpec;
 import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
 import rx.Observable;
 
@@ -99,5 +100,15 @@ public interface Mapper<T> {
      * @throws NullPointerException when either query or queryOptions are null
      */
     Observable<List<T>> query(String query, FeedOptions queryOptions);
+
+    /**
+     * Searches entities by query
+     *
+     * @param query        the {@link SqlQuerySpec} query
+     * @param queryOptions the query options
+     * @return an {@link Observable} containing the single resource response with the created document or an error.
+     * @throws NullPointerException when either query or queryOptions are null
+     */
+    Observable<List<T>> query(SqlQuerySpec query, FeedOptions queryOptions);
 
 }

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/Mapper.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/Mapper.java
@@ -1,0 +1,122 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmosdb.mapper;
+
+import com.microsoft.azure.cosmosdb.FeedOptions;
+import com.microsoft.azure.cosmosdb.RequestOptions;
+import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
+import rx.Observable;
+
+import java.util.List;
+
+/**
+ * An object handling the mapping of a particular class.
+ *
+ * @param <T> the entity class
+ */
+public interface Mapper<T> {
+
+    /**
+     * Creates an entity.
+     *
+     * @param entity the entity to be created in the database
+     * @return an {@link Observable} containing the single resource response with the created document or an error.
+     * @throws NullPointerException when entity is null
+     */
+    Observable<T> create(T entity);
+
+    /**
+     * Creates entities in database.
+     *
+     * @param entities the entities to be created in the database
+     * @return an {@link Observable} containing the merged resource response with the created document or an error.
+     * @throws NullPointerException when either entities is null or there is any null element
+     */
+    Observable<List<T>> create(Iterable<T> entities);
+
+    /**
+     * Updates an entity using {@link AsyncDocumentClient#replaceDocument(String, Object, RequestOptions)}
+     *
+     * @param entity the entity to be updated in the database
+     * @return an {@link Observable} containing the single resource response with the created document or an error.
+     * @throws NullPointerException when entity is null
+     */
+    Observable<T> update(T entity);
+
+    /**
+     * Updates an entity using {@link AsyncDocumentClient#replaceDocument(String, Object, RequestOptions)}
+     * then merge the result
+     *
+     * @param entities the entities to be updated in the database
+     * @return an {@link Observable} containing the merged resource response with the created document or an error.
+     * @throws NullPointerException when either entities is null or there is any null element
+     */
+    Observable<List<T>> update(Iterable<T> entities);
+
+    /**
+     * Finds entity by id
+     *
+     * @param id the entity id
+     * @return an {@link Observable} containing the single resource response with the created document or an error.
+     * @throws NullPointerException when id is null
+     */
+    Observable<T> findById(String id);
+
+    /**
+     * Finds entities by ids
+     *
+     * @param ids the entities ids
+     * @return an {@link Observable} containing the merged resource response with the created document or an error.
+     * @throws NullPointerException when either ids is null or there is any null id
+     */
+    Observable<List<T>> findById(Iterable<String> ids);
+
+    /**
+     * Deletes entity by id
+     *
+     * @param id the entity id
+     * @return an {@link Observable} containing the single resource response with the created document or an error.
+     * @throws NullPointerException when id is null
+     */
+    Observable<Void> deleteById(String id);
+
+    /**
+     * Deletes entities by ids
+     *
+     * @param ids the entities ids
+     * @return an {@link Observable} containing the single resource response with the created document or an error.
+     * @throws NullPointerException when either ids is null or there is any null id
+     */
+    Observable<List<Void>> deleteById(Iterable<String> ids);
+
+    /**
+     * Searches entities by query
+     *
+     * @param query        the String query
+     * @param queryOptions the query options
+     * @return an {@link Observable} containing the single resource response with the created document or an error.
+     * @throws NullPointerException when either query or queryOptions are null
+     */
+    Observable<List<T>> query(String query, FeedOptions queryOptions);
+
+}

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/MappingManager.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/mapper/MappingManager.java
@@ -1,0 +1,58 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmosdb.mapper;
+
+import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
+
+import java.util.Objects;
+
+/**
+ * Mapping manager that obtains entity mappers.
+ */
+public interface MappingManager {
+
+    /**
+     * returns a Mapper instance. Also, check if both document and database do exist based on {@link Entity}
+     * annotation otherwise will create.
+     * @param entityClass the entity class
+     * @param <T> the entity type
+     * @return the Mapper instance
+     * @throws NullPointerException when entityClass is null
+     * @throws IllegalArgumentException when the class is not annotated with {@link Entity}
+     */
+    <T> Mapper<T> mapper(Class<T> entityClass);
+
+
+    /**
+     * returns a {@link MappingManager} instance
+     * @param client the AsyncDocumentClient client
+     * @return a instance
+     * @throws NullPointerException when client is null
+     */
+    static MappingManager of(AsyncDocumentClient client) {
+        Objects.requireNonNull(client, "client is required");
+        return new DefaultMappingManager(client);
+    }
+
+
+}

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadataTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadataTest.java
@@ -1,0 +1,88 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmosdb.mapper;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class EntityMetadataTest {
+
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldReturnErrorWhenEntityIsNotAnnotated() {
+        EntityMetadata.of(User.class);
+    }
+
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldReturnErrorWhenEntityHasDatabaseBlank() {
+        EntityMetadata.of(Person.class);
+    }
+
+    @Test
+    public void shouldReturnEntityWithSimpleClassAsCollectionName() {
+        EntityMetadata metadata = EntityMetadata.of(Animal.class);
+        assertEquals("database", metadata.getDatabaseName());
+        assertEquals(Animal.class.getSimpleName(), metadata.getCollectionName());
+    }
+
+    @Test
+    public void shouldReturnEntity() {
+        EntityMetadata metadata = EntityMetadata.of(Work.class);
+        assertEquals("database", metadata.getDatabaseName());
+        assertEquals("usingAnnotation", metadata.getCollectionName());
+    }
+
+    @Test
+    public void shouldReturnDocumentLink() {
+        EntityMetadata metadata = EntityMetadata.of(Animal.class);
+        assertEquals("/dbs/database/colls/Animal", metadata.getCollectionLink());
+    }
+
+    @Test
+    public void shouldReturnDocumentId() {
+
+        EntityMetadata metadata = EntityMetadata.of(Animal.class);
+        assertEquals("/dbs/database/colls/Animal/docs/id", metadata.getDocumentId("id"));
+    }
+
+    static class User {
+
+    }
+
+    @Entity(databaseName = "")
+    static class Person {
+
+    }
+
+    @Entity(databaseName = "database")
+    static class Animal {
+
+    }
+
+    @Entity(databaseName = "database", collectionName = "usingAnnotation")
+    static class Work {
+
+    }
+}

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadataTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/EntityMetadataTest.java
@@ -25,6 +25,8 @@ package com.microsoft.azure.cosmosdb.mapper;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class EntityMetadataTest {
 
@@ -45,6 +47,7 @@ public class EntityMetadataTest {
         EntityMetadata metadata = EntityMetadata.of(Animal.class);
         assertEquals("database", metadata.getDatabaseName());
         assertEquals(Animal.class.getSimpleName(), metadata.getCollectionName());
+        assertTrue(metadata.isDisableAutomaticIdGeneration());
     }
 
     @Test
@@ -52,12 +55,22 @@ public class EntityMetadataTest {
         EntityMetadata metadata = EntityMetadata.of(Work.class);
         assertEquals("database", metadata.getDatabaseName());
         assertEquals("usingAnnotation", metadata.getCollectionName());
+        assertTrue(metadata.isDisableAutomaticIdGeneration());
+    }
+    
+    @Test
+    public void shouldReturnEntity2() {
+        EntityMetadata metadata = EntityMetadata.of(Soccer.class);
+        assertEquals("database", metadata.getDatabaseName());
+        assertEquals(Soccer.class.getSimpleName(), metadata.getCollectionName());
+        assertFalse(metadata.isDisableAutomaticIdGeneration());
     }
 
     @Test
     public void shouldReturnDocumentLink() {
         EntityMetadata metadata = EntityMetadata.of(Animal.class);
         assertEquals("/dbs/database/colls/Animal", metadata.getCollectionLink());
+
     }
 
     @Test
@@ -83,6 +96,11 @@ public class EntityMetadataTest {
 
     @Entity(databaseName = "database", collectionName = "usingAnnotation")
     static class Work {
+
+    }
+
+    @Entity(databaseName = "database", disableAutomaticIdGeneration = false)
+    static class Soccer {
 
     }
 }

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/MapperTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/MapperTest.java
@@ -24,6 +24,11 @@ package com.microsoft.azure.cosmosdb.mapper;
 
 import com.microsoft.azure.cosmosdb.ConnectionPolicy;
 import com.microsoft.azure.cosmosdb.ConsistencyLevel;
+import com.microsoft.azure.cosmosdb.DocumentClientException;
+import com.microsoft.azure.cosmosdb.FeedOptions;
+import com.microsoft.azure.cosmosdb.SqlParameter;
+import com.microsoft.azure.cosmosdb.SqlParameterCollection;
+import com.microsoft.azure.cosmosdb.SqlQuerySpec;
 import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
 import com.microsoft.azure.cosmosdb.rx.TestConfigurations;
 import org.testng.annotations.Test;
@@ -71,7 +76,7 @@ public class MapperTest {
 
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test(groups = {"internal"}, expectedExceptions = NullPointerException.class)
     public void shouldReturnErrorWhenCreateHasEntityNull() {
         mapper.save((Person) null);
     }
@@ -100,12 +105,12 @@ public class MapperTest {
                 .allMatch(id -> id.equals(ada.getId()) || id.equals(marie.getId())));
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test(groups = {"internal"}, expectedExceptions = NullPointerException.class)
     public void shouldReturnErrorWhenEntitiesIsNull() {
         mapper.save((Iterable<Person>) null);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test(groups = {"internal"}, expectedExceptions = NullPointerException.class)
     public void shouldReturnErrorWhenEntitiesHasANullElement() {
         Person ada = new Person();
         ada.setId("ada" + System.currentTimeMillis());
@@ -116,7 +121,7 @@ public class MapperTest {
     }
 
 
-    @Test
+    @Test(groups = {"internal"})
     public void shouldUpdateEntity() {
         Person ada = new Person();
         ada.setId("ada" + System.currentTimeMillis());
@@ -133,4 +138,206 @@ public class MapperTest {
         assertEquals(ada.getId(), person.getId());
         assertEquals(ada.getAge(), person.getAge());
     }
+
+    @Test(groups = {"internal"}, expectedExceptions = NullPointerException.class)
+    public void shouldReturnErrorWhenFindByIdHasNullId() {
+        mapper.findById((String) null);
+    }
+
+    @Test(groups = {"internal"}, expectedExceptions = NullPointerException.class)
+    public void shouldReturnErrorWhenFindByIdHasNullIds() {
+        mapper.findById((Iterable<String>) null);
+    }
+
+    @Test(groups = {"internal"}, expectedExceptions = NullPointerException.class)
+    public void shouldReturnErrorWhenFindByIdHasANullElement() {
+
+        mapper.findById(Arrays.asList("id", null));
+    }
+
+    @Test(groups = {"internal"}, timeOut = LARGE_TIMEOUT)
+    public void shouldReturnErrorWhenIdDoesNotExist() {
+        Observable<Person> observable = mapper.findById("not_found");
+        try {
+            observable.single().toBlocking().first();
+        } catch (Exception ex) {
+            if (ex.getCause() instanceof DocumentClientException) {
+                return;
+            }
+        }
+
+        assert false;
+    }
+
+    @Test(groups = {"internal"}, timeOut = LARGE_TIMEOUT)
+    public void shouldFindById() {
+
+        Person ada = new Person();
+        ada.setId("ada" + System.currentTimeMillis());
+        ada.setName("Ada Lovelace");
+        ada.setAge(20);
+
+        mapper.save(ada).toBlocking().first();
+
+        Observable<Person> result = mapper.findById(ada.getId());
+
+        Person person = result.single().toBlocking().first();
+
+        assertEquals(ada.getName(), person.getName());
+        assertEquals(ada.getId(), person.getId());
+        assertEquals(ada.getAge(), person.getAge());
+    }
+
+    @Test(groups = {"internal"}, timeOut = LARGE_TIMEOUT)
+    public void shouldFindByIds() {
+
+        Person ada = new Person();
+        ada.setId("ada" + System.currentTimeMillis());
+        ada.setName("Ada Lovelace");
+        ada.setAge(20);
+
+        Person marie = new Person();
+        marie.setId("marie" + System.currentTimeMillis());
+        marie.setName("Marie Curie");
+        marie.setAge(20);
+
+        Observable<List<Person>> observable = mapper.save(Arrays.asList(ada, marie));
+
+        assertNotNull(observable);
+
+        observable.toBlocking().first();
+
+
+        Observable<List<Person>> result = mapper.findById(Arrays.asList(ada.getId(), marie.getId()));
+
+        List<Person> people = result.toBlocking().first();
+
+        assertNotNull(people);
+
+        assertTrue(people.stream().map(Person::getId)
+                .allMatch(id -> id.equals(ada.getId()) || id.equals(marie.getId())));
+    }
+
+    @Test(groups = {"internal"}, expectedExceptions = NullPointerException.class)
+    public void shouldReturnErrorWhenDeleteByIdHasNullId() {
+        mapper.deleteById((String) null);
+    }
+
+    @Test(groups = {"internal"}, expectedExceptions = NullPointerException.class)
+    public void shouldReturnErrorWhenDeleteByHasNullIds() {
+        mapper.deleteById((Iterable<String>) null);
+    }
+
+    @Test(groups = {"internal"}, expectedExceptions = NullPointerException.class)
+    public void shouldReturnErrorWhenDeleteByHasANullElement() {
+        mapper.deleteById(Arrays.asList("id", null));
+    }
+
+
+    @Test(groups = {"internal"})
+    public void shouldReturnErrorWhenDeleteDoesNotRemoveEntity() {
+        Observable<Void> observable = mapper.deleteById("not_found");
+        try {
+            observable.single().toBlocking().first();
+        } catch (Exception ex) {
+            if (ex.getCause() instanceof DocumentClientException) {
+                return;
+            }
+        }
+
+        assert false;
+    }
+
+    @Test(groups = {"internal"})
+    public void shouldRemoveById() {
+        Person ada = new Person();
+        ada.setId("ada" + System.currentTimeMillis());
+        ada.setName("Ada Lovelace");
+        ada.setAge(20);
+
+        mapper.save(ada).toBlocking().first();
+
+        Observable<Void> observable = mapper.deleteById(ada.getId());
+        observable.toBlocking().first();
+
+        try {
+            mapper.findById(ada.getId()).toBlocking().first();
+        } catch (RuntimeException ex) {
+            if (ex.getCause() instanceof DocumentClientException) {
+                return;
+            }
+        }
+
+        assert false;
+
+    }
+
+    @Test(groups = {"internal"}, expectedExceptions = NullPointerException.class)
+    public void shouldReturnErrorWhenQueryHasNullStringQuery() {
+
+        FeedOptions queryOptions = new FeedOptions();
+        mapper.query((String) null, queryOptions);
+    }
+
+    @Test(groups = {"internal"}, expectedExceptions = NullPointerException.class)
+    public void shouldReturnErrorWhenQueryHasNullQueryOptions() {
+        mapper.query("select * from c", null);
+    }
+
+    @Test(groups = {"internal"})
+    public void shouldExecuteQuery() {
+
+        Person ada = new Person();
+        ada.setId("ada" + System.currentTimeMillis());
+        ada.setName("Ada Lovelace");
+        ada.setAge(20);
+
+        Person marie = new Person();
+        marie.setId("marie" + System.currentTimeMillis());
+        marie.setName("Marie Curie");
+        marie.setAge(20);
+
+        mapper.save(Arrays.asList(ada, marie)).toCompletable().await();
+
+        FeedOptions queryOptions = new FeedOptions();
+        queryOptions.setMaxItemCount(100);
+
+        Observable<List<Person>> result =
+                mapper.query("SELECT * FROM Person WHERE Person.name = 'Ada Lovelace'", queryOptions);
+
+        List<Person> people = result.toBlocking().first();
+
+        assertTrue(people.size() > 1);
+        assertTrue(people.stream().map(Person::getName).allMatch(ada.getName()::equals));
+    }
+
+    @Test(groups = {"internal"})
+    public void shouldExecuteQueryBySpec() {
+
+        Person ada = new Person();
+        ada.setId("ada" + System.currentTimeMillis());
+        ada.setName("Ada Lovelace");
+        ada.setAge(20);
+
+        Person marie = new Person();
+        marie.setId("marie" + System.currentTimeMillis());
+        marie.setName("Marie Curie");
+        marie.setAge(20);
+
+        mapper.save(Arrays.asList(ada, marie)).toCompletable().await();
+
+        FeedOptions queryOptions = new FeedOptions();
+        queryOptions.setMaxItemCount(100);
+
+        SqlQuerySpec query = new SqlQuerySpec("SELECT * FROM Person WHERE Person.name = @name",
+                new SqlParameterCollection(new SqlParameter("@name", ada.getName())));
+
+        Observable<List<Person>> result = mapper.query(query, queryOptions);
+
+        List<Person> people = result.toBlocking().first();
+
+        assertTrue(people.size() > 1);
+        assertTrue(people.stream().map(Person::getName).allMatch(ada.getName()::equals));
+    }
+
 }

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/MapperTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/MapperTest.java
@@ -22,8 +22,115 @@
  */
 package com.microsoft.azure.cosmosdb.mapper;
 
-import static org.testng.Assert.*;
+import com.microsoft.azure.cosmosdb.ConnectionPolicy;
+import com.microsoft.azure.cosmosdb.ConsistencyLevel;
+import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
+import com.microsoft.azure.cosmosdb.rx.TestConfigurations;
+import org.testng.annotations.Test;
+import rx.Observable;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 public class MapperTest {
 
+    private final static int LARGE_TIMEOUT = 30000;
+
+    private AsyncDocumentClient client = new AsyncDocumentClient.Builder()
+            .withServiceEndpoint(TestConfigurations.HOST)
+            .withMasterKey(TestConfigurations.MASTER_KEY)
+            .withConnectionPolicy(ConnectionPolicy.GetDefault())
+            .withConsistencyLevel(ConsistencyLevel.Session)
+            .build();
+
+    private Mapper<Person> mapper = MappingManager.of(client).mapper(Person.class);
+
+
+    @Test(groups = {"internal"}, timeOut = LARGE_TIMEOUT)
+    public void shouldCreateEntity() {
+        Person ada = new Person();
+        ada.setId("ada" + System.currentTimeMillis());
+        ada.setName("Ada Lovelace");
+        ada.setAge(20);
+
+        Observable<Person> observable = mapper.save(ada);
+
+        assertNotNull(observable);
+
+        Person person = observable.toBlocking().first();
+
+        assertNotNull(person);
+
+        assertEquals(ada.getName(), person.getName());
+        assertEquals(ada.getAge(), person.getAge());
+        assertEquals(ada.getId(), person.getId());
+
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldReturnErrorWhenCreateHasEntityNull() {
+        mapper.save((Person) null);
+    }
+
+    @Test(groups = {"internal"}, timeOut = LARGE_TIMEOUT)
+    public void shouldCreateEntities() {
+        Person ada = new Person();
+        ada.setId("ada" + System.currentTimeMillis());
+        ada.setName("Ada Lovelace");
+        ada.setAge(20);
+
+        Person marie = new Person();
+        marie.setId("marie" + System.currentTimeMillis());
+        marie.setName("Marie Curie");
+        marie.setAge(20);
+
+        Observable<List<Person>> observable = mapper.save(Arrays.asList(ada, marie));
+
+        assertNotNull(observable);
+
+        List<Person> people = observable.toBlocking().first();
+
+        assertNotNull(people);
+
+        assertTrue(people.stream().map(Person::getId)
+                .allMatch(id -> id.equals(ada.getId()) || id.equals(marie.getId())));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldReturnErrorWhenEntitiesIsNull() {
+        mapper.save((Iterable<Person>) null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldReturnErrorWhenEntitiesHasANullElement() {
+        Person ada = new Person();
+        ada.setId("ada" + System.currentTimeMillis());
+        ada.setName("Ada Lovelace");
+        ada.setAge(20);
+
+        mapper.save(Arrays.asList(ada, null));
+    }
+
+
+    @Test
+    public void shouldUpdateEntity() {
+        Person ada = new Person();
+        ada.setId("ada" + System.currentTimeMillis());
+        ada.setName("Ada Lovelace");
+        ada.setAge(20);
+
+        mapper.save(ada).toBlocking().first();
+
+        ada.setName("Ada Lovelace update");
+
+        Person person = mapper.save(ada).toBlocking().first();
+
+        assertEquals(ada.getName(), person.getName());
+        assertEquals(ada.getId(), person.getId());
+        assertEquals(ada.getAge(), person.getAge());
+    }
 }

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/MapperTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/MapperTest.java
@@ -1,0 +1,29 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmosdb.mapper;
+
+import static org.testng.Assert.*;
+
+public class MapperTest {
+
+}

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/MappingManagerInternalTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/MappingManagerInternalTest.java
@@ -1,0 +1,92 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmosdb.mapper;
+
+import com.microsoft.azure.cosmosdb.ConnectionPolicy;
+import com.microsoft.azure.cosmosdb.ConsistencyLevel;
+import com.microsoft.azure.cosmosdb.Database;
+import com.microsoft.azure.cosmosdb.DocumentCollection;
+import com.microsoft.azure.cosmosdb.FeedResponse;
+import com.microsoft.azure.cosmosdb.ResourceResponse;
+import com.microsoft.azure.cosmosdb.RetryOptions;
+import com.microsoft.azure.cosmosdb.SqlParameter;
+import com.microsoft.azure.cosmosdb.SqlParameterCollection;
+import com.microsoft.azure.cosmosdb.SqlQuerySpec;
+import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
+import com.microsoft.azure.cosmosdb.rx.TestConfigurations;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import rx.Observable;
+
+import java.util.List;
+
+import static org.testng.Assert.assertNotNull;
+
+public class MappingManagerInternalTest {
+
+
+    private final static int LARGE_TIMEOUT = 30000;
+
+
+    @Test(groups = { "internal" }, timeOut = LARGE_TIMEOUT )
+    public void shouldCreateDatabaseCollection() {
+
+        ConnectionPolicy policy = new ConnectionPolicy();
+        RetryOptions retryOptions = new RetryOptions();
+        retryOptions.setMaxRetryAttemptsOnThrottledRequests(Integer.MAX_VALUE);
+        retryOptions.setMaxRetryWaitTimeInSeconds(LARGE_TIMEOUT);
+        policy.setRetryOptions(retryOptions);
+
+        AsyncDocumentClient client = new AsyncDocumentClient.Builder()
+                .withServiceEndpoint(TestConfigurations.HOST)
+                .withMasterKey(TestConfigurations.MASTER_KEY)
+                .withConnectionPolicy(ConnectionPolicy.GetDefault())
+                .withConsistencyLevel(ConsistencyLevel.Session)
+                .build();
+
+        MappingManager mappingManager = MappingManager.of(client);
+
+        Mapper<Person> mapper = mappingManager.mapper(Person.class);
+
+        assertNotNull(mapper);
+        String databaseName = EntityMetadata.of(Person.class).getDatabaseLink();
+        String collectionName = EntityMetadata.of(Person.class).getCollectionName();
+
+
+        Observable<ResourceResponse<Database>> databaseReadObs = client.readDatabase(databaseName, null);
+        ResourceResponse<Database> database = databaseReadObs.single().toBlocking().first();
+        Assert.assertEquals(200, database.getStatusCode());
+
+        FeedResponse<DocumentCollection> documentCollectionFeedResponse = client.queryCollections(databaseName,
+                new SqlQuerySpec("SELECT * FROM r where r.id = @id",
+                        new SqlParameterCollection(
+                                new SqlParameter("@id", collectionName))), null)
+                .toBlocking().first();
+
+        List<DocumentCollection> results = documentCollectionFeedResponse.getResults();
+        Assert.assertEquals(1, results.size());
+        DocumentCollection documentCollection = results.get(0);
+        Assert.assertEquals("Person", documentCollection.getId());
+    }
+
+}

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/MappingManagerTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/MappingManagerTest.java
@@ -1,0 +1,85 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmosdb.mapper;
+
+import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class MappingManagerTest {
+
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldReturnNPEWhenClientIsNull() {
+        MappingManager.of(null);
+    }
+
+    @Test
+    public void shouldReturnMappingManager() {
+        AsyncDocumentClient client = Mockito.mock(AsyncDocumentClient.class);
+        MappingManager mappingManager = MappingManager.of(client);
+        Assert.assertNotNull(mappingManager);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldReturnErrorWhenEntityClassIsNull() {
+        AsyncDocumentClient client = Mockito.mock(AsyncDocumentClient.class);
+        MappingManager mappingManager = MappingManager.of(client);
+        mappingManager.mapper(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldReturnErrorWhenEntityhasNotAnnotation() {
+        AsyncDocumentClient client = Mockito.mock(AsyncDocumentClient.class);
+        MappingManager mappingManager = MappingManager.of(client);
+        mappingManager.mapper(User.class);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldReturnErrorWhenEntityHasDatabaseNameBlank() {
+        AsyncDocumentClient client = Mockito.mock(AsyncDocumentClient.class);
+        MappingManager mappingManager = MappingManager.of(client);
+        mappingManager.mapper(Family.class);
+    }
+
+
+
+    public static class User {
+
+        private String id;
+
+        private String value;
+    }
+
+
+    @Entity(databaseName = "")
+    public static class Family {
+
+        private String id;
+
+        private String value;
+    }
+
+
+}

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/MappingManagerTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/MappingManagerTest.java
@@ -67,18 +67,12 @@ public class MappingManagerTest {
 
     public static class User {
 
-        private String id;
-
-        private String value;
     }
 
 
     @Entity(databaseName = "")
     public static class Family {
 
-        private String id;
-
-        private String value;
     }
 
 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/Person.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/Person.java
@@ -1,0 +1,70 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmosdb.mapper;
+
+import java.io.Serializable;
+
+@Entity(databaseName = "database")
+public class Person implements Serializable {
+
+    private String id;
+
+    private String name;
+
+    private Integer age;
+
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getAge() {
+        return age;
+    }
+
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("Person{");
+        sb.append("id='").append(id).append('\'');
+        sb.append(", name='").append(name).append('\'');
+        sb.append(", age=").append(age);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/Person.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/mapper/Person.java
@@ -24,7 +24,7 @@ package com.microsoft.azure.cosmosdb.mapper;
 
 import java.io.Serializable;
 
-@Entity(databaseName = "database")
+@Entity(databaseName = "AzureSampleFamilyDB")
 public class Person implements Serializable {
 
     private String id;


### PR DESCRIPTION
Adds support to a Mapper that's a wrapper that abstracts these operations to an entity.

E.g.: Given an Person entity:

```java
@Entity(databaseName = "AzureSampleFamilyDB")
public class Person implements Serializable {

    private String id;

    private String name;

    private Integer age;

}
```

You can create a Mapper unit that will handle the operations related to a particular class.

```java
        AsyncDocumentClient client = ...;
        MappingManager mappingManager = MappingManager.of(client);
        Mapper<Person> mapper = mappingManager.mapper(Person.class);
```

```java

        Person ada = new Person();
        ada.setId("ada_" + System.currentTimeMillis());
        ada.setName("Ada Lovelace");
        ada.setAge(20);

        Observable<Person> observable = mapper.save(ada);

        Observable<Person> findById = mapper.findById(ada.getId());


        FeedOptions queryOptions = new FeedOptions();
        queryOptions.setMaxItemCount(100);

        Observable<List<Person>> queryResult = mapper.query("SELECT * FROM Person WHERE Person.name = 'Ada Lovelace'", queryOptions);

         Observable<Void> observable = mapper.deleteById(ada.getId());

```

:warning: Both MappingManager and Mapper should have one instance at Application scope, that is easily handled with frameworks like Spring or CDI.

## Remain tasks:

- [ ] improve the documentation
- [ ] Write an article about this resource
- [ ] write a project sample
- [ ] Write a project sample and post using Spring framework and Mapper
- [ ] Write a project sample and post using JavaEE/JakartaEE  and Mapper

## Next steps to improve the Mapper

IMHO: This PR is just the first step to move forward an easy integration with Mapper.

1) The Repository interface is given an interface that has basic methods a Java developer just need to extend it, so the interface will already be implemented by the Mapper manager. 

```java
public interface PersonRepository extends Repository<Person> {
}
```
```java
    PersonRepository repository = mappingManager.mapper(PersonRepository.class);//ready to use
```

Done: check: https://github.com/Azure/azure-cosmosdb-java/pull/45
2) Support by query by annotation

```java

public interface PersonRepository extends Repository<Person> {
 @Query("SELECT * FROM Person WHERE Person.name = @name")
 Observable<List<Person>> usingQuery(@Param("name") String name);

}
```

Done: check: https://github.com/Azure/azure-cosmosdb-java/pull/45

3) And the old, but gold query by the method where the developer writes the method using conventions and the mapper will down the implementation.

```java

public interface PersonRepository extends Repository<Person> {
 
 Observable<List<Person>> findByName(String name);

}
```