### PR TITLE
WIP Creates an expirable cache

### DIFF
--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCache.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCache.java
@@ -1,0 +1,165 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmosdb.rx.internal.caches;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.unmodifiableCollection;
+import static java.util.Collections.unmodifiableSet;
+
+/**
+ *A Map implementation that expires based on TTL {@link TTLCache#of(long, TimeUnit)}
+ * @param <K> the key type
+ * @param <V> the value type
+ */
+public class TTLCache<K, V> implements Map<K, V> {
+
+    private final Map<K, V> store = new ConcurrentHashMap<>();
+    private final Map<K, Long> timestamps = new ConcurrentHashMap<>();
+    private final long ttl;
+
+    private TTLCache(long ttl) {
+        this.ttl = ttl;
+    }
+
+    @Override
+    public V get(Object key) {
+        V value = this.store.get(key);
+
+        if (value != null && checkExpired(key)) {
+            return null;
+        } else {
+            return value;
+        }
+    }
+
+    @Override
+    public V put(K key, V value) {
+        timestamps.put(key, System.nanoTime());
+        return store.put(key, value);
+    }
+
+    @Override
+    public int size() {
+        return store.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return store.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        boolean containsKey = store.containsKey(key);
+        return containsKey ? !checkExpired(key) : containsKey;
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return store.containsValue(value);
+    }
+
+    @Override
+    public V remove(Object key) {
+        timestamps.remove(key);
+        return store.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> map) {
+        Objects.requireNonNull(map, "map is required");
+        map.entrySet().forEach(this::put);
+    }
+
+    @Override
+    public void clear() {
+        timestamps.clear();
+        store.clear();
+    }
+
+    @Override
+    public Set<K> keySet() {
+        clearExpired();
+        return unmodifiableSet(store.keySet());
+    }
+
+    @Override
+    public Collection<V> values() {
+        clearExpired();
+        return unmodifiableCollection(store.values());
+    }
+
+    @Override
+    public Set<java.util.Map.Entry<K, V>> entrySet() {
+        clearExpired();
+        return unmodifiableSet(store.entrySet());
+    }
+
+    private void clearExpired() {
+        store.keySet().stream().forEach(this::checkExpired);
+    }
+
+    private void put(Entry<? extends K, ? extends V> entry) {
+        this.put(entry.getKey(), entry.getValue());
+    }
+
+    private boolean checkExpired(Object key) {
+        if (isExpired(key)) {
+            remove(key);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isExpired(Object key) {
+        return (System.nanoTime() - timestamps.get(key)) > this.ttl;
+    }
+
+    /**
+     * Creates a {@link Map} that expires values from the TTL defined
+     * @param value the value
+     * @param timeUnit the unit
+     * @param <K> the key type
+     * @param <V> the value type
+     * @return a new {@link TTLCache} instance
+     * @throws NullPointerException when timeUnit is null
+     * @throws IllegalArgumentException when value is negative or zero
+     */
+    public static <K,V> Map<K, V> of(long value, TimeUnit timeUnit) {
+        Objects.requireNonNull(timeUnit, "timeUnit is required");
+        if(value <= 0) {
+            throw new IllegalArgumentException("The value to TTL must be greater than zero");
+        }
+        return new TTLCache<>(timeUnit.toNanos(value));
+    }
+
+}

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCache.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCache.java
@@ -145,7 +145,8 @@ public class TTLCache<K, V> implements Map<K, V> {
     }
 
     /**
-     * Creates a {@link Map} that expires values from the TTL defined
+     * Creates a {@link Map} that expires values from the TTL defined.
+     * The value is represented by milliseconds, so any amount lower than one millisecond will come around to one.
      * @param value the value
      * @param timeUnit the unit
      * @param <K> the key type
@@ -159,6 +160,7 @@ public class TTLCache<K, V> implements Map<K, V> {
         if(value <= 0) {
             throw new IllegalArgumentException("The value to TTL must be greater than zero");
         }
+        System.out.println("ttl: " + timeUnit.toNanos(value));
         return new TTLCache<>(timeUnit.toNanos(value));
     }
 

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCache.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCache.java
@@ -146,7 +146,7 @@ public class TTLCache<K, V> implements Map<K, V> {
 
     /**
      * Creates a {@link Map} that expires values from the TTL defined.
-     * The value is represented by milliseconds, so any amount lower than one millisecond will come around to one.
+     * The value is represented by nanoseconds, so any amount lower than one nanosecond will come around to one.
      * @param value the value
      * @param timeUnit the unit
      * @param <K> the key type
@@ -160,7 +160,6 @@ public class TTLCache<K, V> implements Map<K, V> {
         if(value <= 0) {
             throw new IllegalArgumentException("The value to TTL must be greater than zero");
         }
-        System.out.println("ttl: " + timeUnit.toNanos(value));
         return new TTLCache<>(timeUnit.toNanos(value));
     }
 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCacheTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCacheTest.java
@@ -22,6 +22,7 @@
  */
 package com.microsoft.azure.cosmosdb.rx.internal.caches;
 
+import org.apache.commons.lang3.builder.ToStringExclude;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -69,11 +70,66 @@ public class TTLCacheTest {
 
     @Test
     public void shouldGet() throws InterruptedException {
-        Map<String, Integer> map = TTLCache.of(10, TimeUnit.SECONDS);
+        Map<String, Integer> map = TTLCache.of(2, TimeUnit.MILLISECONDS);
         map.put("one", 1);
         assertNotNull(map.get("one"));
-        TimeUnit.NANOSECONDS.sleep(12L);
+        TimeUnit.MILLISECONDS.sleep(5L);
         assertNull(map.get("one"));
     }
 
+    @Test
+    public void shouldGetSize() {
+        Map<String, Integer> map = TTLCache.of(2, TimeUnit.MILLISECONDS);
+        assertEquals(0, map.size());
+        map.put("one", 1);
+        assertEquals(1, map.size());
+        map.put("two", 2);
+        assertEquals(2, map.size());
+    }
+
+    @Test
+    public void shouldGetEmpty() {
+        Map<String, Integer> map = TTLCache.of(2, TimeUnit.MILLISECONDS);
+        assertTrue(map.isEmpty());
+        map.put("one", 1);
+        assertFalse(map.isEmpty());
+    }
+
+    @Test
+    public void shouldContains() throws InterruptedException {
+        Map<String, Integer> map = TTLCache.of(2, TimeUnit.MILLISECONDS);
+        map.put("one", 1);
+        assertTrue(map.containsKey("one"));
+        TimeUnit.MILLISECONDS.sleep(5L);
+        assertFalse(map.containsKey("one"));
+    }
+
+    @Test
+    public void shouldContainsValue() {
+        Map<String, Integer> map = TTLCache.of(2, TimeUnit.MILLISECONDS);
+        map.put("one", 1);
+        assertTrue(map.containsValue(1));
+        assertFalse(map.containsValue(2));
+    }
+
+    @Test
+    public void shouldRemove() {
+        Map<String, Integer> map = TTLCache.of(2, TimeUnit.MILLISECONDS);
+        map.put("one", 1);
+        assertTrue(map.containsKey("one"));
+        map.remove("one");
+        assertFalse(map.containsKey("one"));
+    }
+
+    @Test
+    public void shouldClear() {
+        Map<String, Integer> map = TTLCache.of(2, TimeUnit.MILLISECONDS);
+        map.put("one", 1);
+        map.put("two", 1);
+        assertFalse(map.isEmpty());
+        map.clear();
+        assertTrue(map.isEmpty());
+    }
+
+    
 }

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCacheTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCacheTest.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmosdb.rx.internal.caches;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.*;
+
+public class TTLCacheTest {
+
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldReturnErrorWhenDurationIsNull() {
+        TTLCache.of(1, null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldReturnIllegalWhenValueIsNegative() {
+        TTLCache.of(-1, TimeUnit.DAYS);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldReturnIllegalWhenValueIsZero() {
+        TTLCache.of(0, TimeUnit.DAYS);
+    }
+
+    @Test
+    public void shouldCreateInstance() {
+        assertNotNull(TTLCache.of(1L, TimeUnit.DAYS));
+        assertNotNull(TTLCache.of(1L, TimeUnit.HOURS));
+        assertNotNull(TTLCache.of(1L, TimeUnit.MINUTES));
+        assertNotNull(TTLCache.of(1L, TimeUnit.SECONDS));
+        assertNotNull(TTLCache.of(1L, TimeUnit.MICROSECONDS));
+        assertNotNull(TTLCache.of(1L, TimeUnit.NANOSECONDS));
+        assertNotNull(TTLCache.of(1L, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void shouldPut() throws InterruptedException {
+        Map<String, Integer> map = TTLCache.of(1, TimeUnit.NANOSECONDS);
+        assertNull(map.put("one", 1));
+        assertNotNull(map.put("one", 1));
+        TimeUnit.NANOSECONDS.sleep(1L);
+        assertNull(map.put("one", 1));
+    }
+
+
+}

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCacheTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCacheTest.java
@@ -27,6 +27,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -131,5 +132,60 @@ public class TTLCacheTest {
         assertTrue(map.isEmpty());
     }
 
-    
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shouldReturnErrorWhenPutAllIsNull() {
+        Map<String, Integer> map = TTLCache.of(2, TimeUnit.MILLISECONDS);
+        map.putAll(null);
+    }
+
+    @Test
+    public void shouldPutAll() throws InterruptedException {
+        Map<String, Integer> map = TTLCache.of(2, TimeUnit.MILLISECONDS);
+        map.putAll(Collections.singletonMap("one", 1));
+        assertTrue(map.containsKey("one"));
+        TimeUnit.MILLISECONDS.sleep(5L);
+        assertFalse(map.containsKey("one"));
+    }
+
+    @Test
+    public void shouldReturnKeySet() throws InterruptedException {
+        Map<String, Integer> map = TTLCache.of(2, TimeUnit.MILLISECONDS);
+        assertTrue(map.keySet().isEmpty());
+        map.put("one", 1);
+        map.put("two", 2);
+        assertFalse(map.keySet().isEmpty());
+        assertEquals(2, map.keySet().size());
+        TimeUnit.MILLISECONDS.sleep(5L);
+        map.put("four", 4);
+        assertFalse(map.keySet().isEmpty());
+        assertEquals(1, map.keySet().size());
+    }
+
+    @Test
+    public void shouldReturnValues() throws InterruptedException {
+        Map<String, Integer> map = TTLCache.of(2, TimeUnit.MILLISECONDS);
+        assertTrue(map.values().isEmpty());
+        map.put("one", 1);
+        map.put("two", 2);
+        assertFalse(map.values().isEmpty());
+        assertEquals(2, map.values().size());
+        TimeUnit.MILLISECONDS.sleep(5L);
+        map.put("four", 4);
+        assertFalse(map.values().isEmpty());
+        assertEquals(1, map.values().size());
+    }
+
+    @Test
+    public void shouldReturnEntrySet() throws InterruptedException {
+        Map<String, Integer> map = TTLCache.of(2, TimeUnit.MILLISECONDS);
+        assertTrue(map.entrySet().isEmpty());
+        map.put("one", 1);
+        map.put("two", 2);
+        assertFalse(map.entrySet().isEmpty());
+        assertEquals(2, map.entrySet().size());
+        TimeUnit.MILLISECONDS.sleep(5L);
+        map.put("four", 4);
+        assertFalse(map.entrySet().isEmpty());
+        assertEquals(1, map.entrySet().size());
+    }
 }

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCacheTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCacheTest.java
@@ -22,16 +22,17 @@
  */
 package com.microsoft.azure.cosmosdb.rx.internal.caches;
 
-import org.apache.commons.lang3.builder.ToStringExclude;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 public class TTLCacheTest {
 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCacheTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/caches/TTLCacheTest.java
@@ -61,13 +61,19 @@ public class TTLCacheTest {
     }
 
     @Test
-    public void shouldPut() throws InterruptedException {
+    public void shouldPut() {
         Map<String, Integer> map = TTLCache.of(1, TimeUnit.NANOSECONDS);
         assertNull(map.put("one", 1));
         assertNotNull(map.put("one", 1));
-        TimeUnit.NANOSECONDS.sleep(1L);
-        assertNull(map.put("one", 1));
     }
 
+    @Test
+    public void shouldGet() throws InterruptedException {
+        Map<String, Integer> map = TTLCache.of(10, TimeUnit.SECONDS);
+        map.put("one", 1);
+        assertNotNull(map.get("one"));
+        TimeUnit.NANOSECONDS.sleep(12L);
+        assertNull(map.get("one"));
+    }
 
 }


### PR DESCRIPTION
This PR contains a cache that expires from given a specific value. To make this cache easier to use, it implements the Map interface.

```java
   Map<String, Integer> map = TTLCache.of(2, TimeUnit.MILLISECONDS);
   map.put("one", 1);
   Integer value = map.get("one");
   TimeUnit.MILLISECONDS.sleep(3L);
   value = map.get("one");//it will be null
```