### PR TITLE
Upgrade to newer release of the maven-javadoc-plugin

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -96,7 +96,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.0.1</version>
         <configuration>
           <links>
             <link>http://reactivex.io/RxJava/javadoc/</link>


### PR DESCRIPTION
Building the SDK under JDK 11 fails due to the outdated version of maven-javadoc-plugin specified in the Maven pom file. Version 2.9.1 was released in June 2013, and is not supported under JDK 11. I have changed this to instead use 3.0.1, which was released in May 2018. SDK compilation now succeeds under JDK 11 (as well as earlier JDK releases).