### PR TITLE
Refactoring V3 SDK Client

### DIFF
--- a/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxGatewayStoreModel.java
+++ b/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxGatewayStoreModel.java
@@ -72,7 +72,7 @@ import java.util.Map.Entry;
  * 
  * Used internally to provide functionality to communicate and process response from Gateway in the Azure Cosmos DB database service.
  */
-class RxGatewayStoreModel implements RxStoreModel {
+public class RxGatewayStoreModel implements RxStoreModel {
 
     private final static int INITIAL_RESPONSE_BUFFER_SIZE = 1024;
     private final Logger logger = LoggerFactory.getLogger(RxGatewayStoreModel.class);

--- a/sdk/src/main/java/com/microsoft/azure/cosmos/CosmosContainer.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmos/CosmosContainer.java
@@ -68,7 +68,7 @@ public class CosmosContainer extends CosmosResource {
      * @return an {@link Mono} containing the single cossmos container response with the read container or an error.
      */
     public Mono<CosmosContainerResponse> read(CosmosContainerRequestOptions requestOptions) {
-        return RxJava2Adapter.singleToMono(RxJavaInterop.toV2Single(database.getDocClientWrapper().readCollection(getLink(),
+        return RxJava2Adapter.singleToMono(RxJavaInterop.toV2Single(database.getCosmosClientInternalWrapper().readCollection(getLink(),
                                                                                                      requestOptions.toRequestOptions())
                 .map(response -> new CosmosContainerResponse(response, database)).toSingle()));
     }
@@ -85,7 +85,7 @@ public class CosmosContainer extends CosmosResource {
      */
     public Mono<CosmosContainerResponse> delete(CosmosContainerRequestOptions requestOptions) {
         return RxJava2Adapter.singleToMono(
-                RxJavaInterop.toV2Single(database.getDocClientWrapper()
+                RxJavaInterop.toV2Single(database.getCosmosClientInternalWrapper()
                                                  .deleteCollection(getLink(),requestOptions.toRequestOptions())
                                                  .map(response -> new CosmosContainerResponse(response, database))
                                                  .toSingle()));
@@ -122,7 +122,7 @@ public class CosmosContainer extends CosmosResource {
             requestOptions = new CosmosContainerRequestOptions();
         }
         return RxJava2Adapter.singleToMono(
-                RxJavaInterop.toV2Single(database.getDocClientWrapper()
+                RxJavaInterop.toV2Single(database.getCosmosClientInternalWrapper()
                                                  .replaceCollection(containerSettings.getV2Collection(),requestOptions.toRequestOptions())
                                                  .map(response -> new CosmosContainerResponse(response, database))
                                                  .toSingle()));
@@ -172,7 +172,7 @@ public class CosmosContainer extends CosmosResource {
      */
     public Mono<CosmosItemResponse> createItem(Object item, CosmosItemRequestOptions options) {
         return RxJava2Adapter.singleToMono(
-                RxJavaInterop.toV2Single(database.getDocClientWrapper()
+                RxJavaInterop.toV2Single(database.getCosmosClientInternalWrapper()
                                                  .createDocument(getLink(),CosmosItem.fromObject(item),options.toRequestOptions(), true)
                                                  .map(response -> new CosmosItemResponse(response, this))
                                                  .toSingle()));
@@ -191,7 +191,7 @@ public class CosmosContainer extends CosmosResource {
      */
     public Mono<CosmosItemResponse> upsertItem(Object item, CosmosItemRequestOptions options){
         return RxJava2Adapter.singleToMono(RxJavaInterop.toV2Single(this.getDatabase()
-                                                                            .getDocClientWrapper()
+                                                                            .getCosmosClientInternalWrapper()
                                                                             .upsertDocument(this.getLink(),
                                                                                             item,
                                                                                             options.toRequestOptions(),
@@ -225,7 +225,7 @@ public class CosmosContainer extends CosmosResource {
      */
     public Flux<FeedResponse<CosmosItem>> listItems(FeedOptions options) {
         return RxJava2Adapter.flowableToFlux(
-                RxJavaInterop.toV2Flowable(getDatabase().getDocClientWrapper()
+                RxJavaInterop.toV2Flowable(getDatabase().getCosmosClientInternalWrapper()
                                                    .readDocuments(getLink(), options)
                                                    .map(response-> BridgeInternal.createFeedResponse(CosmosItem.getFromV2Results(response.getResults(),this),
                                                                                                      response.getResponseHeaders()))));
@@ -260,7 +260,7 @@ public class CosmosContainer extends CosmosResource {
     public Flux<FeedResponse<CosmosItem>> queryItems(SqlQuerySpec querySpec, FeedOptions options){
         return RxJava2Adapter.flowableToFlux(
                 RxJavaInterop.toV2Flowable(getDatabase()
-                                                   .getDocClientWrapper()
+                                                   .getCosmosClientInternalWrapper()
                                                    .queryDocuments(getLink(), querySpec, options)
                                                    .map(response-> BridgeInternal.createFeedResponseWithQueryMetrics(
                                                            CosmosItem.getFromV2Results(response.getResults(), this),
@@ -296,7 +296,7 @@ public class CosmosContainer extends CosmosResource {
         sProc.setId(settings.getId());
         sProc.setBody(settings.getBody());
         return RxJava2Adapter.singleToMono(
-                RxJavaInterop.toV2Single(database.getDocClientWrapper()
+                RxJavaInterop.toV2Single(database.getCosmosClientInternalWrapper()
                                                  .createStoredProcedure(getLink(), sProc, options.toRequestOptions())
                                                  .map(response -> new CosmosStoredProcedureResponse(response, this))
                                                  .toSingle()));
@@ -315,7 +315,7 @@ public class CosmosContainer extends CosmosResource {
      */
     public Flux<FeedResponse<CosmosStoredProcedureSettings>> listStoredProcedures(FeedOptions options){
         return RxJava2Adapter.flowableToFlux(
-                RxJavaInterop.toV2Flowable(database.getDocClientWrapper()
+                RxJavaInterop.toV2Flowable(database.getCosmosClientInternalWrapper()
                                                    .readStoredProcedures(getLink(), options)
                                                    .map(response -> BridgeInternal.createFeedResponse(CosmosStoredProcedureSettings.getFromV2Results(response.getResults()),
                                                                                                       response.getResponseHeaders()))));
@@ -353,7 +353,7 @@ public class CosmosContainer extends CosmosResource {
     public Flux<FeedResponse<CosmosStoredProcedureSettings>> queryStoredProcedures(SqlQuerySpec querySpec,
                                                                                        FeedOptions options){
         return RxJava2Adapter.flowableToFlux(
-                RxJavaInterop.toV2Flowable(database.getDocClientWrapper()
+                RxJavaInterop.toV2Flowable(database.getCosmosClientInternalWrapper()
                                                    .queryStoredProcedures(getLink(), querySpec,options)
                                                    .map(response -> BridgeInternal.createFeedResponse( CosmosStoredProcedureSettings.getFromV2Results(response.getResults()),
                                                                                                        response.getResponseHeaders()))));
@@ -379,7 +379,7 @@ public class CosmosContainer extends CosmosResource {
         udf.setId(settings.getId());
         udf.setBody(settings.getBody());
         return RxJava2Adapter.singleToMono(
-                RxJavaInterop.toV2Single(database.getDocClientWrapper()
+                RxJavaInterop.toV2Single(database.getCosmosClientInternalWrapper()
                                                  .createUserDefinedFunction(getLink(), udf, options.toRequestOptions())
                                                  .map(response -> new CosmosUserDefinedFunctionResponse(response, this)).toSingle()));
     }
@@ -396,7 +396,7 @@ public class CosmosContainer extends CosmosResource {
      */
     public Flux<FeedResponse<CosmosUserDefinedFunctionSettings>> listUserDefinedFunctions(FeedOptions options){
         return RxJava2Adapter.flowableToFlux(
-                RxJavaInterop.toV2Flowable(database.getDocClientWrapper()
+                RxJavaInterop.toV2Flowable(database.getCosmosClientInternalWrapper()
                                                    .readUserDefinedFunctions(getLink(), options)
                                                    .map(response -> BridgeInternal.createFeedResponse(CosmosUserDefinedFunctionSettings.getFromV2Results(response.getResults()),
                                                                                                       response.getResponseHeaders()))));
@@ -432,7 +432,7 @@ public class CosmosContainer extends CosmosResource {
     public Flux<FeedResponse<CosmosUserDefinedFunctionSettings>> queryUserDefinedFunctions(SqlQuerySpec querySpec,
                                                                                                FeedOptions options){
         return RxJava2Adapter.flowableToFlux(
-                RxJavaInterop.toV2Flowable(database.getDocClientWrapper()
+                RxJavaInterop.toV2Flowable(database.getCosmosClientInternalWrapper()
                                                    .queryUserDefinedFunctions(getLink(),querySpec, options)
                                                    .map(response -> BridgeInternal.createFeedResponse(CosmosUserDefinedFunctionSettings.getFromV2Results(response.getResults()),
                                                                                                       response.getResponseHeaders()))));
@@ -453,7 +453,7 @@ public class CosmosContainer extends CosmosResource {
                                                        CosmosRequestOptions options){
         Trigger trigger = new Trigger(settings.toJson());
         return RxJava2Adapter.singleToMono(
-                RxJavaInterop.toV2Single(database.getDocClientWrapper()
+                RxJavaInterop.toV2Single(database.getCosmosClientInternalWrapper()
                                                  .createTrigger(getLink(), trigger,options.toRequestOptions())
                                                  .map(response -> new CosmosTriggerResponse(response, this))
                                                  .toSingle()));
@@ -471,7 +471,7 @@ public class CosmosContainer extends CosmosResource {
      */
     public Flux<FeedResponse<CosmosTriggerSettings>> listTriggers(FeedOptions options){
         return RxJava2Adapter.flowableToFlux(
-                RxJavaInterop.toV2Flowable(database.getDocClientWrapper()
+                RxJavaInterop.toV2Flowable(database.getCosmosClientInternalWrapper()
                                                    .readTriggers(getLink(), options)
                                                    .map(response -> BridgeInternal.createFeedResponse(CosmosTriggerSettings.getFromV2Results(response.getResults()),
                                                                                                       response.getResponseHeaders()))));
@@ -506,7 +506,7 @@ public class CosmosContainer extends CosmosResource {
     public Flux<FeedResponse<CosmosTriggerSettings>> queryTriggers(SqlQuerySpec querySpec,
                                                      FeedOptions options){
         return RxJava2Adapter.flowableToFlux(
-                RxJavaInterop.toV2Flowable(database.getDocClientWrapper()
+                RxJavaInterop.toV2Flowable(database.getCosmosClientInternalWrapper()
                                                    .queryTriggers(getLink(), querySpec, options)
                                                    .map(response -> BridgeInternal.createFeedResponse(CosmosTriggerSettings.getFromV2Results(response.getResults()),
                                                                                                       response.getResponseHeaders()))));

--- a/sdk/src/main/java/com/microsoft/azure/cosmos/CosmosDatabase.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmos/CosmosDatabase.java
@@ -22,6 +22,7 @@
  */
 package com.microsoft.azure.cosmos;
 
+import com.microsoft.azure.cosmos.internal.CosmosClientInternal;
 import com.microsoft.azure.cosmosdb.BridgeInternal;
 import com.microsoft.azure.cosmosdb.DocumentClientException;
 import com.microsoft.azure.cosmosdb.FeedOptions;
@@ -30,7 +31,6 @@ import com.microsoft.azure.cosmosdb.RequestOptions;
 import com.microsoft.azure.cosmosdb.SqlQuerySpec;
 import com.microsoft.azure.cosmosdb.internal.HttpConstants;
 import com.microsoft.azure.cosmosdb.internal.Paths;
-import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
 
 import hu.akarnokd.rxjava.interop.RxJavaInterop;
 import org.apache.commons.lang3.StringUtils;
@@ -73,7 +73,7 @@ public class CosmosDatabase extends CosmosResource {
      * @return an {@link Mono} containing the single cosmos database response with the read database or an error.
      */
     public Mono<CosmosDatabaseResponse> read(CosmosDatabaseRequestOptions options) {
-        return RxJava2Adapter.singleToMono(RxJavaInterop.toV2Single(getDocClientWrapper().readDatabase(getLink(),
+        return RxJava2Adapter.singleToMono(RxJavaInterop.toV2Single(getCosmosClientInternalWrapper().readDatabase(getLink(),
                                                                                           options.toRequestOptions())
                 .map(response -> new CosmosDatabaseResponse(response, getClient())).toSingle()));
     }
@@ -102,7 +102,7 @@ public class CosmosDatabase extends CosmosResource {
      */
     public Mono<CosmosDatabaseResponse> delete(CosmosRequestOptions options) {
         return RxJava2Adapter.singleToMono(
-                RxJavaInterop.toV2Single(getDocClientWrapper()
+                RxJavaInterop.toV2Single(getCosmosClientInternalWrapper()
                                                  .deleteDatabase(getLink(), options.toRequestOptions())
                                                  .map(response -> new CosmosDatabaseResponse(response, getClient()))
                                                  .toSingle()));
@@ -140,7 +140,7 @@ public class CosmosDatabase extends CosmosResource {
      */
     public Mono<CosmosContainerResponse> createContainer(CosmosContainerSettings containerSettings,
             CosmosContainerRequestOptions options) {
-        return RxJava2Adapter.singleToMono(RxJavaInterop.toV2Single(getDocClientWrapper().createCollection(this.getLink(),
+        return RxJava2Adapter.singleToMono(RxJavaInterop.toV2Single(getCosmosClientInternalWrapper().createCollection(this.getLink(),
                 containerSettings.getV2Collection(), options.toRequestOptions()).map(response ->
                 new CosmosContainerResponse(response, this)).toSingle()));
     }
@@ -220,7 +220,7 @@ public class CosmosDatabase extends CosmosResource {
      */
     public Flux<FeedResponse<CosmosContainerSettings>> listContainers(FeedOptions options) {
         //TODO:
-        return RxJava2Adapter.flowableToFlux(RxJavaInterop.toV2Flowable(getDocClientWrapper().readCollections(getLink(), options)
+        return RxJava2Adapter.flowableToFlux(RxJavaInterop.toV2Flowable(getCosmosClientInternalWrapper().readCollections(getLink(), options)
                 .map(response-> BridgeInternal.createFeedResponse(CosmosContainerSettings.getFromV2Results(response.getResults()),
                         response.getResponseHeaders()))));
     }
@@ -265,7 +265,7 @@ public class CosmosDatabase extends CosmosResource {
      * @return an {@link Flux} containing one or several feed response pages of the obtained containers or an error.
      */
     public Flux<FeedResponse<CosmosContainerSettings>> queryContainers(SqlQuerySpec querySpec, FeedOptions options){
-        return RxJava2Adapter.flowableToFlux(RxJavaInterop.toV2Flowable(getDocClientWrapper().queryCollections(getLink(), querySpec,
+        return RxJava2Adapter.flowableToFlux(RxJavaInterop.toV2Flowable(getCosmosClientInternalWrapper().queryCollections(getLink(), querySpec,
                                                                                                 options)
                 .map(response-> BridgeInternal.createFeedResponse(
                         CosmosContainerSettings.getFromV2Results(response.getResults()),
@@ -285,8 +285,8 @@ public class CosmosDatabase extends CosmosResource {
         return client;
     }
 
-    AsyncDocumentClient getDocClientWrapper(){
-        return client.getDocClientWrapper();
+    CosmosClientInternal getCosmosClientInternalWrapper(){
+        return client.getCosmosClientInternalWrapper();
     }
 
     @Override

--- a/sdk/src/main/java/com/microsoft/azure/cosmos/CosmosItem.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmos/CosmosItem.java
@@ -85,7 +85,7 @@ public class CosmosItem extends Resource {
      * @return an {@link Mono} containing the cosmos item response with the read item or an error
      */
     public Mono<CosmosItemResponse> read(CosmosItemRequestOptions requestOptions) {
-        return RxJava2Adapter.singleToMono(RxJavaInterop.toV2Single(container.getDatabase().getDocClientWrapper()
+        return RxJava2Adapter.singleToMono(RxJavaInterop.toV2Single(container.getDatabase().getCosmosClientInternalWrapper()
                 .readDocument(getLink(), requestOptions.toRequestOptions())
                 .map(response -> new CosmosItemResponse(response, container)).toSingle()));
     }
@@ -119,7 +119,7 @@ public class CosmosItem extends Resource {
     public Mono<CosmosItemResponse> replace(Object item, CosmosItemRequestOptions requestOptions){
         Document doc = CosmosItem.fromObject(item);
         return RxJava2Adapter.singleToMono(RxJavaInterop.toV2Single(container.getDatabase()
-                .getDocClientWrapper()
+                .getCosmosClientInternalWrapper()
                 .replaceDocument(doc, requestOptions.toRequestOptions())
                 .map(response -> new CosmosItemResponse(response, container)).toSingle()));
     }
@@ -150,7 +150,7 @@ public class CosmosItem extends Resource {
     public Mono<CosmosItemResponse> delete(CosmosItemRequestOptions options){
         return RxJava2Adapter.singleToMono(
                 RxJavaInterop.toV2Single(container.getDatabase()
-                                                 .getDocClientWrapper()
+                                                 .getCosmosClientInternalWrapper()
                                                  .deleteDocument(getLink(),options.toRequestOptions())
                                                  .map(response -> new CosmosItemResponse(response, container))
                                                  .toSingle()));

--- a/sdk/src/main/java/com/microsoft/azure/cosmos/CosmosStoredProcedure.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmos/CosmosStoredProcedure.java
@@ -60,7 +60,7 @@ public class CosmosStoredProcedure extends CosmosResource {
      * @return an {@link Mono} containing the single resource response with the read stored procedure or an error.
      */
     public Mono<CosmosStoredProcedureResponse> read(RequestOptions options){
-        return RxJava2Adapter.singleToMono(RxJavaInterop.toV2Single(cosmosContainer.getDatabase().getDocClientWrapper().readStoredProcedure(getLink(), options)
+        return RxJava2Adapter.singleToMono(RxJavaInterop.toV2Single(cosmosContainer.getDatabase().getCosmosClientInternalWrapper().readStoredProcedure(getLink(), options)
         .map(response -> new CosmosStoredProcedureResponse(response, cosmosContainer)).toSingle()));
     }
 
@@ -77,7 +77,7 @@ public class CosmosStoredProcedure extends CosmosResource {
     public Mono<CosmosResponse> delete(CosmosRequestOptions options){
         return RxJava2Adapter.singleToMono(
                 RxJavaInterop.toV2Single(cosmosContainer.getDatabase()
-                                                 .getDocClientWrapper()
+                                                 .getCosmosClientInternalWrapper()
                                                  .deleteStoredProcedure(getLink(), options.toRequestOptions())
                                                  .map(response -> new CosmosResponse(response.getResource()))
                                                  .toSingle()));
@@ -97,7 +97,7 @@ public class CosmosStoredProcedure extends CosmosResource {
     public Mono<CosmosStoredProcedureResponse> execute(Object[] procedureParams, RequestOptions options){
         return RxJava2Adapter.singleToMono(
                 RxJavaInterop.toV2Single(cosmosContainer.getDatabase()
-                                                 .getDocClientWrapper()
+                                                 .getCosmosClientInternalWrapper()
                                                  .executeStoredProcedure(getLink(), options, procedureParams)
                                                  .map(response -> new CosmosStoredProcedureResponse(response, cosmosContainer))
                                                  .toSingle()));
@@ -118,7 +118,7 @@ public class CosmosStoredProcedure extends CosmosResource {
                                                          RequestOptions options){
         return RxJava2Adapter.singleToMono(
                 RxJavaInterop.toV2Single(cosmosContainer.getDatabase()
-                                                 .getDocClientWrapper()
+                                                 .getCosmosClientInternalWrapper()
                                                  .replaceStoredProcedure(new StoredProcedure(storedProcedureSettings.toJson()), options)
                                                  .map(response -> new CosmosStoredProcedureResponse(response, cosmosContainer))
                                                  .toSingle()));

--- a/sdk/src/main/java/com/microsoft/azure/cosmos/CosmosTrigger.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmos/CosmosTrigger.java
@@ -61,7 +61,7 @@ public class CosmosTrigger extends CosmosResource{
     public Mono<CosmosTriggerResponse> read(RequestOptions options){
         return RxJava2Adapter.singleToMono(
                 RxJavaInterop.toV2Single(container.getDatabase()
-                                                 .getDocClientWrapper()
+                                                 .getCosmosClientInternalWrapper()
                                                  .readTrigger(getLink(), options)
                                                  .map(response -> new CosmosTriggerResponse(response, container))
                                                  .toSingle()));
@@ -82,7 +82,7 @@ public class CosmosTrigger extends CosmosResource{
     public Mono<CosmosTriggerResponse> replace(CosmosTriggerSettings triggerSettings, RequestOptions options){
         return RxJava2Adapter.singleToMono(
                 RxJavaInterop.toV2Single(container.getDatabase()
-                                                 .getDocClientWrapper()
+                                                 .getCosmosClientInternalWrapper()
                                                  .replaceTrigger(new Trigger(triggerSettings.toJson()), options)
                                                  .map(response -> new CosmosTriggerResponse(response, container))
                                                  .toSingle()));
@@ -101,7 +101,7 @@ public class CosmosTrigger extends CosmosResource{
     public Mono<CosmosResponse> delete(CosmosRequestOptions options){
         return RxJava2Adapter.singleToMono(
                 RxJavaInterop.toV2Single(container.getDatabase()
-                                                 .getDocClientWrapper()
+                                                 .getCosmosClientInternalWrapper()
                                                  .deleteTrigger(getLink(), options.toRequestOptions())
                                                  .map(response -> new CosmosResponse(response.getResource()))
                                                  .toSingle()));

--- a/sdk/src/main/java/com/microsoft/azure/cosmos/CosmosUserDefinedFunction.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmos/CosmosUserDefinedFunction.java
@@ -49,7 +49,7 @@ public class CosmosUserDefinedFunction extends CosmosResource{
      * @return an {@link Mono} containing the single resource response for the read user defined function or an error.
      */
     public Mono<CosmosUserDefinedFunctionResponse> read(RequestOptions options){
-        return RxJava2Adapter.singleToMono(RxJavaInterop.toV2Single(container.getDatabase().getDocClientWrapper().readUserDefinedFunction(getLink(), options)
+        return RxJava2Adapter.singleToMono(RxJavaInterop.toV2Single(container.getDatabase().getCosmosClientInternalWrapper().readUserDefinedFunction(getLink(), options)
                 .map(response -> new CosmosUserDefinedFunctionResponse(response, container)).toSingle()));
     }
 
@@ -70,7 +70,7 @@ public class CosmosUserDefinedFunction extends CosmosResource{
             RequestOptions options){
         return RxJava2Adapter.singleToMono(
                 RxJavaInterop.toV2Single(container.getDatabase()
-                                                 .getDocClientWrapper()
+                                                 .getCosmosClientInternalWrapper()
                                                  .replaceUserDefinedFunction(new UserDefinedFunction(udfSettings.toJson())
                                                          , options)
                                                  .map(response -> new CosmosUserDefinedFunctionResponse(response, container))
@@ -91,7 +91,7 @@ public class CosmosUserDefinedFunction extends CosmosResource{
     public Mono<CosmosResponse> delete(CosmosRequestOptions options){
         return RxJava2Adapter.singleToMono(
                 RxJavaInterop.toV2Single(container.getDatabase()
-                                                 .getDocClientWrapper()
+                                                 .getCosmosClientInternalWrapper()
                                                  .deleteUserDefinedFunction(this.getLink(), options.toRequestOptions())
                                                  .map(response -> new CosmosResponse(response.getResource()))
                                                  .toSingle()));

--- a/sdk/src/main/java/com/microsoft/azure/cosmos/internal/CosmosClientInternal.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmos/internal/CosmosClientInternal.java
@@ -1,0 +1,1518 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmos.internal;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import com.microsoft.azure.cosmosdb.Attachment;
+import com.microsoft.azure.cosmosdb.ChangeFeedOptions;
+import com.microsoft.azure.cosmosdb.Conflict;
+import com.microsoft.azure.cosmosdb.ConnectionPolicy;
+import com.microsoft.azure.cosmosdb.ConsistencyLevel;
+import com.microsoft.azure.cosmosdb.Database;
+import com.microsoft.azure.cosmosdb.DatabaseAccount;
+import com.microsoft.azure.cosmosdb.Document;
+import com.microsoft.azure.cosmosdb.DocumentCollection;
+import com.microsoft.azure.cosmosdb.FeedOptions;
+import com.microsoft.azure.cosmosdb.FeedResponse;
+import com.microsoft.azure.cosmosdb.MediaOptions;
+import com.microsoft.azure.cosmosdb.MediaResponse;
+import com.microsoft.azure.cosmosdb.Offer;
+import com.microsoft.azure.cosmosdb.PartitionKeyRange;
+import com.microsoft.azure.cosmosdb.Permission;
+import com.microsoft.azure.cosmosdb.RequestOptions;
+import com.microsoft.azure.cosmosdb.ResourceResponse;
+import com.microsoft.azure.cosmosdb.SqlQuerySpec;
+import com.microsoft.azure.cosmosdb.StoredProcedure;
+import com.microsoft.azure.cosmosdb.StoredProcedureResponse;
+import com.microsoft.azure.cosmosdb.TokenResolver;
+import com.microsoft.azure.cosmosdb.Trigger;
+import com.microsoft.azure.cosmosdb.User;
+import com.microsoft.azure.cosmosdb.UserDefinedFunction;
+import com.microsoft.azure.cosmosdb.rx.internal.Configs;
+
+import rx.Observable;
+
+/**
+ * Provides a client-side logical representation of the Azure Cosmos DB
+ * database service. This async client is used to configure and execute requests
+ * against the service.
+ *
+ * <p>
+ * {@link CosmosClientInternal} async APIs return <a href="https://github.com/ReactiveX/RxJava">rxJava</a>'s {@code
+ * Observable}, and so you can use rxJava {@link Observable} functionality.
+ * <STRONG>The async {@link Observable} based APIs perform the requested operation only after
+ * subscription.</STRONG>
+ *
+ * <p>
+ * The service client encapsulates the endpoint and credentials used to access
+ * the Cosmos DB service.
+ * <p>
+ * To instantiate you can use the {@link Builder}
+ * <pre>
+ * {@code
+ * ConnectionPolicy connectionPolicy = new ConnectionPolicy();
+ * connectionPolicy.setConnectionMode(ConnectionMode.Direct);
+ * CosmosClientInternal client = new CosmosClientInternal.Builder()
+ *         .withServiceEndpoint(serviceEndpoint)
+ *         .withMasterKeyOrResourceToken(masterKey)
+ *         .withConnectionPolicy(connectionPolicy)
+ *         .withConsistencyLevel(ConsistencyLevel.Session)
+ *         .build();
+ * }
+ * </pre>
+ */
+public interface CosmosClientInternal {
+
+    /**
+     * Helper class to build {@link CosmosClientInternal} instances
+     * as logical representation of the Azure Cosmos DB database service.
+     *
+     * <pre>
+     * {@code
+     * ConnectionPolicy connectionPolicy = new ConnectionPolicy();
+     * connectionPolicy.setConnectionMode(ConnectionMode.Direct);
+     * CosmosClientInternal client = new CosmosClientInternal.Builder()
+     *         .withServiceEndpoint(serviceEndpoint)
+     *         .withMasterKeyOrResourceToken(masterKey)
+     *         .withConnectionPolicy(connectionPolicy)
+     *         .withConsistencyLevel(ConsistencyLevel.Session)
+     *         .build();
+     * }
+     * </pre>
+     */
+    class Builder {
+
+        Configs configs = new Configs();
+        ConnectionPolicy connectionPolicy;
+        ConsistencyLevel desiredConsistencyLevel;
+        List<Permission> permissionFeed;
+        String masterKeyOrResourceToken;
+        URI serviceEndpoint;
+        TokenResolver tokenResolver;
+
+        public Builder withServiceEndpoint(String serviceEndpoint) {
+            try {
+                this.serviceEndpoint = new URI(serviceEndpoint);
+            } catch (URISyntaxException e) {
+                throw new IllegalArgumentException(e.getMessage());
+            }
+            return this;
+        }
+
+        /**
+         * New method withMasterKeyOrResourceToken will take either master key or resource token
+         * and perform authentication for accessing resource.
+         *
+         * @param masterKeyOrResourceToken MasterKey or resourceToken for authentication.
+         * @return current Builder.
+         * @deprecated use {@link #withMasterKeyOrResourceToken(String)} instead.
+         */
+        @Deprecated
+        public Builder withMasterKey(String masterKeyOrResourceToken) {
+            this.masterKeyOrResourceToken = masterKeyOrResourceToken;
+            return this;
+        }
+
+        /**
+         * This method will accept the master key , additionally it can also consume
+         * resource token too for authentication.
+         *
+         * @param masterKeyOrResourceToken MasterKey or resourceToken for authentication.
+         * @return current Builder.
+         */
+        public Builder withMasterKeyOrResourceToken(String masterKeyOrResourceToken) {
+            this.masterKeyOrResourceToken = masterKeyOrResourceToken;
+            return this;
+        }
+
+        /**
+         * This method will accept the permission list , which contains the
+         * resource tokens needed to access resources.
+         *
+         * @param permissionFeed Permission list for authentication.
+         * @return current Builder.
+         */
+        public Builder withPermissionFeed(List<Permission> permissionFeed) {
+            this.permissionFeed = permissionFeed;
+            return this;
+        }
+
+        public Builder withConsistencyLevel(ConsistencyLevel desiredConsistencyLevel) {
+            this.desiredConsistencyLevel = desiredConsistencyLevel;
+            return this;
+        }
+
+        public Builder withConfigs(Configs configs) {
+            this.configs = configs;
+            return this;
+        }
+
+        public Builder withConnectionPolicy(ConnectionPolicy connectionPolicy) {
+            this.connectionPolicy = connectionPolicy;
+            return this;
+        }
+
+        /**
+         * This method will accept tokenResolver which is rx function, it takes arguments<br>
+         * T1 requestVerb(String),<br>
+         * T2 resourceIdOrFullName(String),<br>
+         * T3 resourceType(com.microsoft.azure.cosmosdb.internal.ResourceType),<br>
+         * T4 request headers(Map<String, String>)<br>
+         *<br>
+         * and return<br>
+         * R authenticationToken(String)<br>
+         *
+         * @param tokenResolver tokenResolver function for authentication.
+         * @return current Builder.
+         */
+        /*public Builder withTokenResolver(Func4<String, String, ResourceType, Map<String, String>, String> tokenResolver) {
+            this.tokenResolver = tokenResolver;
+            return this;
+        }*/
+
+        /**
+         * This method will accept functional interface TokenResolver which helps in generation authorization
+         * token per request. CosmosClientInternal can be successfully initialized with this API without passing any MasterKey, ResourceToken or PermissionFeed.
+         * @param tokenResolver The tokenResolver
+         * @return current Builder.
+         */
+        public Builder withTokenResolver(TokenResolver tokenResolver) {
+            this.tokenResolver = tokenResolver;
+            return this;
+        }
+
+        private void ifThrowIllegalArgException(boolean value, String error) {
+            if (value) {
+                throw new IllegalArgumentException(error);
+            }
+        }
+
+        public CosmosClientInternal build() {
+
+            ifThrowIllegalArgException(this.serviceEndpoint == null, "cannot build client without service endpoint");
+            ifThrowIllegalArgException(
+                    this.masterKeyOrResourceToken == null && (permissionFeed == null || permissionFeed.isEmpty()) && this.tokenResolver == null,
+                    "cannot build client without any one of masterKey, resource token, permissionFeed and tokenResolver");
+
+            CosmosClientContext client = new CosmosClientContext(serviceEndpoint,
+                                                                   masterKeyOrResourceToken,
+                                                                   permissionFeed,
+                                                                   connectionPolicy,
+                                                                   desiredConsistencyLevel,
+                                                                   configs,
+                                                                   tokenResolver);
+            client.init();
+            return client;
+        }
+
+        public Configs getConfigs() {
+            return configs;
+        }
+
+        public void setConfigs(Configs configs) {
+            this.configs = configs;
+        }
+
+        public ConnectionPolicy getConnectionPolicy() {
+            return connectionPolicy;
+        }
+
+        public void setConnectionPolicy(ConnectionPolicy connectionPolicy) {
+            this.connectionPolicy = connectionPolicy;
+        }
+
+        public ConsistencyLevel getDesiredConsistencyLevel() {
+            return desiredConsistencyLevel;
+        }
+
+        public void setDesiredConsistencyLevel(ConsistencyLevel desiredConsistencyLevel) {
+            this.desiredConsistencyLevel = desiredConsistencyLevel;
+        }
+
+        public List<Permission> getPermissionFeed() {
+            return permissionFeed;
+        }
+
+        public void setPermissionFeed(List<Permission> permissionFeed) {
+            this.permissionFeed = permissionFeed;
+        }
+
+        public String getMasterKeyOrResourceToken() {
+            return masterKeyOrResourceToken;
+        }
+
+        public void setMasterKeyOrResourceToken(String masterKeyOrResourceToken) {
+            this.masterKeyOrResourceToken = masterKeyOrResourceToken;
+        }
+
+        public URI getServiceEndpoint() {
+            return serviceEndpoint;
+        }
+
+        public void setServiceEndpoint(URI serviceEndpoint) {
+            this.serviceEndpoint = serviceEndpoint;
+        }
+
+        public TokenResolver getTokenResolver() {
+            return tokenResolver;
+        }
+
+        public void setTokenResolver(TokenResolver tokenResolver) {
+            this.tokenResolver = tokenResolver;
+        }
+    }
+
+    /**
+     * Gets the default service endpoint as passed in by the user during construction.
+     *
+     * @return the service endpoint URI
+     */
+    URI getServiceEndpoint();
+
+    /**
+     * Gets the current write endpoint chosen based on availability and preference.
+     *
+     * @return the write endpoint URI
+     */
+    URI getWriteEndpoint();
+
+    /**
+     * Gets the current read endpoint chosen based on availability and preference.
+     *
+     * @return the read endpoint URI
+     */
+    URI getReadEndpoint();
+
+    /**
+     * Gets the connection policy
+     *
+     * @return the connection policy
+     */
+    ConnectionPolicy getConnectionPolicy();
+
+    /**
+     * Creates a database.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the created database.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param database the database.
+     * @param options  the request options.
+     * @return an {@link Observable} containing the single resource response with the created database or an error.
+     */
+    Observable<ResourceResponse<Database>> createDatabase(Database database, RequestOptions options);
+
+    /**
+     * Deletes a database.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the deleted database.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param databaseLink the database link.
+     * @param options      the request options.
+     * @return an {@link Observable} containing the single resource response with the deleted database or an error.
+     */
+    Observable<ResourceResponse<Database>> deleteDatabase(String databaseLink, RequestOptions options);
+
+    /**
+     * Reads a database.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the read database.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param databaseLink the database link.
+     * @param options      the request options.
+     * @return an {@link Observable} containing the single resource response with the read database or an error.
+     */
+    Observable<ResourceResponse<Database>> readDatabase(String databaseLink, RequestOptions options);
+
+    /**
+     * Reads all databases.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response of the read databases.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param options the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of read databases or an error.
+     */
+    Observable<FeedResponse<Database>> readDatabases(FeedOptions options);
+
+    /**
+     * Query for databases.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response of the read databases.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param query   the query.
+     * @param options the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of read databases or an error.
+     */
+    Observable<FeedResponse<Database>> queryDatabases(String query, FeedOptions options);
+
+    /**
+     * Query for databases.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response of the obtained databases.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param querySpec the SQL query specification.
+     * @param options   the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained databases or an error.
+     */
+    Observable<FeedResponse<Database>> queryDatabases(SqlQuerySpec querySpec, FeedOptions options);
+
+    /**
+     * Creates a document collection.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the created collection.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param databaseLink the database link.
+     * @param collection   the collection.
+     * @param options      the request options.
+     * @return an {@link Observable} containing the single resource response with the created collection or an error.
+     */
+    Observable<ResourceResponse<DocumentCollection>> createCollection(String databaseLink, DocumentCollection collection,
+                                                                      RequestOptions options);
+
+    /**
+     * Replaces a document collection.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the replaced document collection.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collection the document collection to use.
+     * @param options    the request options.
+     * @return an {@link Observable} containing the single resource response with the replaced document collection or an error.
+     */
+    Observable<ResourceResponse<DocumentCollection>> replaceCollection(DocumentCollection collection, RequestOptions options);
+
+    /**
+     * Deletes a document collection by the collection link.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response for the deleted database.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param options        the request options.
+     * @return an {@link Observable} containing the single resource response for the deleted database or an error.
+     */
+    Observable<ResourceResponse<DocumentCollection>> deleteCollection(String collectionLink, RequestOptions options);
+
+    /**
+     * Reads a document collection by the collection link.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the read collection.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param options        the request options.
+     * @return an {@link Observable} containing the single resource response with the read collection or an error.
+     */
+    Observable<ResourceResponse<DocumentCollection>> readCollection(String collectionLink, RequestOptions options);
+
+    /**
+     * Reads all document collections in a database.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response of the read collections.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param databaseLink the database link.
+     * @param options      the fee options.
+     * @return an {@link Observable} containing one or several feed response pages of the read collections or an error.
+     */
+    Observable<FeedResponse<DocumentCollection>> readCollections(String databaseLink, FeedOptions options);
+
+    /**
+     * Query for document collections in a database.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response of the obtained collections.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param databaseLink the database link.
+     * @param query        the query.
+     * @param options      the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained collections or an error.
+     */
+    Observable<FeedResponse<DocumentCollection>> queryCollections(String databaseLink, String query, FeedOptions options);
+
+    /**
+     * Query for document collections in a database.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response of the obtained collections.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param databaseLink the database link.
+     * @param querySpec    the SQL query specification.
+     * @param options      the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained collections or an error.
+     */
+    Observable<FeedResponse<DocumentCollection>> queryCollections(String databaseLink, SqlQuerySpec querySpec, FeedOptions options);
+
+    /**
+     * Creates a document.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the created document.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink               the link to the parent document collection.
+     * @param document                     the document represented as a POJO or Document object.
+     * @param options                      the request options.
+     * @param disableAutomaticIdGeneration the flag for disabling automatic id generation.
+     * @return an {@link Observable} containing the single resource response with the created document or an error.
+     */
+    Observable<ResourceResponse<Document>> createDocument(String collectionLink, Object document, RequestOptions options,
+                                                          boolean disableAutomaticIdGeneration);
+
+    /**
+     * Upserts a document.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the upserted document.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink               the link to the parent document collection.
+     * @param document                     the document represented as a POJO or Document object to upsert.
+     * @param options                      the request options.
+     * @param disableAutomaticIdGeneration the flag for disabling automatic id generation.
+     * @return an {@link Observable} containing the single resource response with the upserted document or an error.
+     */
+    Observable<ResourceResponse<Document>> upsertDocument(String collectionLink, Object document, RequestOptions options,
+                                                          boolean disableAutomaticIdGeneration);
+
+    /**
+     * Replaces a document using a POJO object.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the replaced document.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param documentLink the document link.
+     * @param document     the document represented as a POJO or Document object.
+     * @param options      the request options.
+     * @return an {@link Observable} containing the single resource response with the replaced document or an error.
+     */
+    Observable<ResourceResponse<Document>> replaceDocument(String documentLink, Object document, RequestOptions options);
+
+    /**
+     * Replaces a document with the passed in document.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the replaced document.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param document the document to replace (containing the document id).
+     * @param options  the request options.
+     * @return an {@link Observable} containing the single resource response with the replaced document or an error.
+     */
+    Observable<ResourceResponse<Document>> replaceDocument(Document document, RequestOptions options);
+
+    /**
+     * Deletes a document by the document link.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response for the deleted document.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param documentLink the document link.
+     * @param options      the request options.
+     * @return an {@link Observable} containing the single resource response for the deleted document or an error.
+     */
+    Observable<ResourceResponse<Document>> deleteDocument(String documentLink, RequestOptions options);
+
+    /**
+     * Reads a document by the document link.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the read document.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param documentLink the document link.
+     * @param options      the request options.
+     * @return an {@link Observable} containing the single resource response with the read document or an error.
+     */
+    Observable<ResourceResponse<Document>> readDocument(String documentLink, RequestOptions options);
+
+    /**
+     * Reads all documents in a document collection.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response of the read documents.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the read documents or an error.
+     */
+    Observable<FeedResponse<Document>> readDocuments(String collectionLink, FeedOptions options);
+
+
+    /**
+     * Query for documents in a document collection.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response of the obtained documents.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the link to the parent document collection.
+     * @param query          the query.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained document or an error.
+     */
+    Observable<FeedResponse<Document>> queryDocuments(String collectionLink, String query, FeedOptions options);
+
+    /**
+     * Query for documents in a document collection.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response of the obtained documents.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the link to the parent document collection.
+     * @param querySpec      the SQL query specification.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained documents or an error.
+     */
+    Observable<FeedResponse<Document>> queryDocuments(String collectionLink, SqlQuerySpec querySpec, FeedOptions options);
+
+    /**
+     * Query for documents change feed in a document collection.
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained documents.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink    the link to the parent document collection.
+     * @param changeFeedOptions the change feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained documents or an error.
+     */
+    Observable<FeedResponse<Document>> queryDocumentChangeFeed(String collectionLink,
+                                                               ChangeFeedOptions changeFeedOptions);
+
+    /**
+     * Reads all partition key ranges in a document collection.
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained partition key ranges.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the link to the parent document collection.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained partition key ranges or an error.
+     */
+    Observable<FeedResponse<PartitionKeyRange>> readPartitionKeyRanges(String collectionLink, FeedOptions options);
+
+    /**
+     * Creates a stored procedure.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the created stored procedure.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink  the collection link.
+     * @param storedProcedure the stored procedure to create.
+     * @param options         the request options.
+     * @return an {@link Observable} containing the single resource response with the created stored procedure or an error.
+     */
+    Observable<ResourceResponse<StoredProcedure>> createStoredProcedure(String collectionLink, StoredProcedure storedProcedure,
+                                                                        RequestOptions options);
+
+    /**
+     * Upserts a stored procedure.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the upserted stored procedure.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink  the collection link.
+     * @param storedProcedure the stored procedure to upsert.
+     * @param options         the request options.
+     * @return an {@link Observable} containing the single resource response with the upserted stored procedure or an error.
+     */
+    Observable<ResourceResponse<StoredProcedure>> upsertStoredProcedure(String collectionLink, StoredProcedure storedProcedure,
+                                                                        RequestOptions options);
+
+    /**
+     * Replaces a stored procedure.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the replaced stored procedure.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param storedProcedure the stored procedure to use.
+     * @param options         the request options.
+     * @return an {@link Observable} containing the single resource response with the replaced stored procedure or an error.
+     */
+    Observable<ResourceResponse<StoredProcedure>> replaceStoredProcedure(StoredProcedure storedProcedure, RequestOptions options);
+
+    /**
+     * Deletes a stored procedure by the stored procedure link.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response for the deleted stored procedure.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param storedProcedureLink the stored procedure link.
+     * @param options             the request options.
+     * @return an {@link Observable} containing the single resource response for the deleted stored procedure or an error.
+     */
+    Observable<ResourceResponse<StoredProcedure>> deleteStoredProcedure(String storedProcedureLink, RequestOptions options);
+
+    /**
+     * Read a stored procedure by the stored procedure link.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the read stored procedure.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param storedProcedureLink the stored procedure link.
+     * @param options             the request options.
+     * @return an {@link Observable} containing the single resource response with the read stored procedure or an error.
+     */
+    Observable<ResourceResponse<StoredProcedure>> readStoredProcedure(String storedProcedureLink, RequestOptions options);
+
+    /**
+     * Reads all stored procedures in a document collection link.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the read stored procedures.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the read stored procedures or an error.
+     */
+    Observable<FeedResponse<StoredProcedure>> readStoredProcedures(String collectionLink, FeedOptions options);
+
+    /**
+     * Query for stored procedures in a document collection.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained stored procedures.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param query          the query.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained stored procedures or an error.
+     */
+    Observable<FeedResponse<StoredProcedure>> queryStoredProcedures(String collectionLink, String query, FeedOptions options);
+
+    /**
+     * Query for stored procedures in a document collection.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained stored procedures.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param querySpec      the SQL query specification.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained stored procedures or an error.
+     */
+    Observable<FeedResponse<StoredProcedure>> queryStoredProcedures(String collectionLink, SqlQuerySpec querySpec,
+                                                                    FeedOptions options);
+
+    /**
+     * Executes a stored procedure by the stored procedure link.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the stored procedure response.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param storedProcedureLink the stored procedure link.
+     * @param procedureParams     the array of procedure parameter values.
+     * @return an {@link Observable} containing the single resource response with the stored procedure response or an error.
+     */
+    Observable<StoredProcedureResponse> executeStoredProcedure(String storedProcedureLink, Object[] procedureParams);
+
+    /**
+     * Executes a stored procedure by the stored procedure link.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the stored procedure response.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param storedProcedureLink the stored procedure link.
+     * @param options             the request options.
+     * @param procedureParams     the array of procedure parameter values.
+     * @return an {@link Observable} containing the single resource response with the stored procedure response or an error.
+     */
+    Observable<StoredProcedureResponse> executeStoredProcedure(String storedProcedureLink, RequestOptions options,
+                                                               Object[] procedureParams);
+
+    /**
+     * Creates a trigger.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the created trigger.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param trigger        the trigger.
+     * @param options        the request options.
+     * @return an {@link Observable} containing the single resource response with the created trigger or an error.
+     */
+    Observable<ResourceResponse<Trigger>> createTrigger(String collectionLink, Trigger trigger, RequestOptions options);
+
+    /**
+     * Upserts a trigger.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the upserted trigger.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param trigger        the trigger to upsert.
+     * @param options        the request options.
+     * @return an {@link Observable} containing the single resource response with the upserted trigger or an error.
+     */
+    Observable<ResourceResponse<Trigger>> upsertTrigger(String collectionLink, Trigger trigger, RequestOptions options);
+
+    /**
+     * Replaces a trigger.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the replaced trigger.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param trigger the trigger to use.
+     * @param options the request options.
+     * @return an {@link Observable} containing the single resource response with the replaced trigger or an error.
+     */
+    Observable<ResourceResponse<Trigger>> replaceTrigger(Trigger trigger, RequestOptions options);
+
+    /**
+     * Deletes a trigger.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response for the deleted trigger.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param triggerLink the trigger link.
+     * @param options     the request options.
+     * @return an {@link Observable} containing the single resource response for the deleted trigger or an error.
+     */
+    Observable<ResourceResponse<Trigger>> deleteTrigger(String triggerLink, RequestOptions options);
+
+    /**
+     * Reads a trigger by the trigger link.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response for the read trigger.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param triggerLink the trigger link.
+     * @param options     the request options.
+     * @return an {@link Observable} containing the single resource response for the read trigger or an error.
+     */
+    Observable<ResourceResponse<Trigger>> readTrigger(String triggerLink, RequestOptions options);
+
+    /**
+     * Reads all triggers in a document collection.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the read triggers.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the read triggers or an error.
+     */
+    Observable<FeedResponse<Trigger>> readTriggers(String collectionLink, FeedOptions options);
+
+    /**
+     * Query for triggers.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained triggers.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param query          the query.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained triggers or an error.
+     */
+    Observable<FeedResponse<Trigger>> queryTriggers(String collectionLink, String query, FeedOptions options);
+
+    /**
+     * Query for triggers.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained triggers.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param querySpec      the SQL query specification.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained triggers or an error.
+     */
+    Observable<FeedResponse<Trigger>> queryTriggers(String collectionLink, SqlQuerySpec querySpec, FeedOptions options);
+
+    /**
+     * Creates a user defined function.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the created user defined function.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param udf            the user defined function.
+     * @param options        the request options.
+     * @return an {@link Observable} containing the single resource response with the created user defined function or an error.
+     */
+    Observable<ResourceResponse<UserDefinedFunction>> createUserDefinedFunction(String collectionLink, UserDefinedFunction udf,
+                                                                                RequestOptions options);
+
+    /**
+     * Upserts a user defined function.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the upserted user defined function.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param udf            the user defined function to upsert.
+     * @param options        the request options.
+     * @return an {@link Observable} containing the single resource response with the upserted user defined function or an error.
+     */
+    Observable<ResourceResponse<UserDefinedFunction>> upsertUserDefinedFunction(String collectionLink, UserDefinedFunction udf,
+                                                                                RequestOptions options);
+
+    /**
+     * Replaces a user defined function.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the replaced user defined function.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param udf     the user defined function.
+     * @param options the request options.
+     * @return an {@link Observable} containing the single resource response with the replaced user defined function or an error.
+     */
+    Observable<ResourceResponse<UserDefinedFunction>> replaceUserDefinedFunction(UserDefinedFunction udf, RequestOptions options);
+
+    /**
+     * Deletes a user defined function.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response for the deleted user defined function.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param udfLink the user defined function link.
+     * @param options the request options.
+     * @return an {@link Observable} containing the single resource response for the deleted user defined function or an error.
+     */
+    Observable<ResourceResponse<UserDefinedFunction>> deleteUserDefinedFunction(String udfLink, RequestOptions options);
+
+    /**
+     * Read a user defined function.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response for the read user defined function.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param udfLink the user defined function link.
+     * @param options the request options.
+     * @return an {@link Observable} containing the single resource response for the read user defined function or an error.
+     */
+    Observable<ResourceResponse<UserDefinedFunction>> readUserDefinedFunction(String udfLink, RequestOptions options);
+
+    /**
+     * Reads all user defined functions in a document collection.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the read user defined functions.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the read user defined functions or an error.
+     */
+    Observable<FeedResponse<UserDefinedFunction>> readUserDefinedFunctions(String collectionLink, FeedOptions options);
+
+    /**
+     * Query for user defined functions.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained user defined functions.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param query          the query.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained user defined functions or an error.
+     */
+    Observable<FeedResponse<UserDefinedFunction>> queryUserDefinedFunctions(String collectionLink, String query,
+                                                                            FeedOptions options);
+
+    /**
+     * Query for user defined functions.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained user defined functions.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param querySpec      the SQL query specification.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained user defined functions or an error.
+     */
+    Observable<FeedResponse<UserDefinedFunction>> queryUserDefinedFunctions(String collectionLink, SqlQuerySpec querySpec,
+                                                                            FeedOptions options);
+
+    /**
+     * Creates an attachment.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the created attachment.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param documentLink the document link.
+     * @param attachment   the attachment to create.
+     * @param options      the request options.
+     * @return an {@link Observable} containing the single resource response with the created attachment or an error.
+     */
+    Observable<ResourceResponse<Attachment>> createAttachment(String documentLink, Attachment attachment, RequestOptions options);
+
+    /**
+     * Upserts an attachment.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the upserted attachment.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param documentLink the document link.
+     * @param attachment   the attachment to upsert.
+     * @param options      the request options.
+     * @return an {@link Observable} containing the single resource response with the upserted attachment or an error.
+     */
+    Observable<ResourceResponse<Attachment>> upsertAttachment(String documentLink, Attachment attachment, RequestOptions options);
+
+    /**
+     * Replaces an attachment.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the replaced attachment.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param attachment the attachment to use.
+     * @param options    the request options.
+     * @return an {@link Observable} containing the single resource response with the replaced attachment or an error.
+     */
+    Observable<ResourceResponse<Attachment>> replaceAttachment(Attachment attachment, RequestOptions options);
+
+    /**
+     * Deletes an attachment.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response for the deleted attachment.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param attachmentLink the attachment link.
+     * @param options        the request options.
+     * @return an {@link Observable} containing the single resource response for the deleted attachment or an error.
+     */
+    Observable<ResourceResponse<Attachment>> deleteAttachment(String attachmentLink, RequestOptions options);
+
+    /**
+     * Reads an attachment.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the read attachment.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param attachmentLink the attachment link.
+     * @param options        the request options.
+     * @return an {@link Observable} containing the single resource response with the read attachment or an error.
+     */
+    Observable<ResourceResponse<Attachment>> readAttachment(String attachmentLink, RequestOptions options);
+
+    /**
+     * Reads all attachments in a document.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the read attachments.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param documentLink the document link.
+     * @param options      the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the read attachments or an error.
+     */
+    Observable<FeedResponse<Attachment>> readAttachments(String documentLink, FeedOptions options);
+
+
+    /**
+     * Reads a media by the media link.
+     *
+     * @param mediaLink the media link.
+     * @return the media response.
+     */
+    Observable<MediaResponse> readMedia(String mediaLink);
+
+    /**
+     * Updates a media by the media link.
+     *
+     * @param mediaLink   the media link.
+     * @param mediaStream the media stream to upload.
+     * @param options     the media options.
+     * @return the media response.
+     */
+    Observable<MediaResponse> updateMedia(String mediaLink, InputStream mediaStream, MediaOptions options);
+
+    /**
+     * Query for attachments.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained attachments.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param documentLink the document link.
+     * @param query        the query.
+     * @param options      the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained attachments or an error.
+     */
+    Observable<FeedResponse<Attachment>> queryAttachments(String documentLink, String query, FeedOptions options);
+
+    /**
+     * Query for attachments.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained attachments.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param documentLink the document link.
+     * @param querySpec    the SQL query specification.
+     * @param options      the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained attachments or an error.
+     */
+    Observable<FeedResponse<Attachment>> queryAttachments(String documentLink, SqlQuerySpec querySpec, FeedOptions options);
+
+    /**
+     * Creates an attachment.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the created attachment.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param documentLink   the document link.
+     * @param mediaStream    the media stream for creating the attachment.
+     * @param options        the media options.
+     * @param requestOptions the request options
+     * @return an {@link Observable} containing the single resource response with the created attachment or an error.
+     */
+    Observable<ResourceResponse<Attachment>> createAttachment(String documentLink, InputStream mediaStream, MediaOptions options, RequestOptions requestOptions);
+
+    /**
+     * Upserts an attachment to the media stream
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the upserted attachment.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param documentLink   the document link.
+     * @param mediaStream    the media stream for upserting the attachment.
+     * @param options        the media options.
+     * @param requestOptions the request options
+     * @return an {@link Observable} containing the single resource response with the upserted attachment or an error.
+     */
+    Observable<ResourceResponse<Attachment>> upsertAttachment(String documentLink, InputStream mediaStream, MediaOptions options, RequestOptions requestOptions);
+
+    /**
+     * Reads a conflict.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the read conflict.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param conflictLink the conflict link.
+     * @param options      the request options.
+     * @return an {@link Observable} containing the single resource response with the read conflict or an error.
+     */
+    Observable<ResourceResponse<Conflict>> readConflict(String conflictLink, RequestOptions options);
+
+    /**
+     * Reads all conflicts in a document collection.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the read conflicts.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the read conflicts or an error.
+     */
+    Observable<FeedResponse<Conflict>> readConflicts(String collectionLink, FeedOptions options);
+
+    /**
+     * Query for conflicts.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained conflicts.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param query          the query.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained conflicts or an error.
+     */
+    Observable<FeedResponse<Conflict>> queryConflicts(String collectionLink, String query, FeedOptions options);
+
+    /**
+     * Query for conflicts.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained conflicts.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param collectionLink the collection link.
+     * @param querySpec      the SQL query specification.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained conflicts or an error.
+     */
+    Observable<FeedResponse<Conflict>> queryConflicts(String collectionLink, SqlQuerySpec querySpec, FeedOptions options);
+
+    /**
+     * Deletes a conflict.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response for the deleted conflict.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param conflictLink the conflict link.
+     * @param options      the request options.
+     * @return an {@link Observable} containing the single resource response for the deleted conflict or an error.
+     */
+    Observable<ResourceResponse<Conflict>> deleteConflict(String conflictLink, RequestOptions options);
+
+    /**
+     * Creates a user.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the created user.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param databaseLink the database link.
+     * @param user         the user to create.
+     * @param options      the request options.
+     * @return an {@link Observable} containing the single resource response with the created user or an error.
+     */
+    Observable<ResourceResponse<User>> createUser(String databaseLink, User user, RequestOptions options);
+
+    /**
+     * Upserts a user.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the upserted user.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param databaseLink the database link.
+     * @param user         the user to upsert.
+     * @param options      the request options.
+     * @return an {@link Observable} containing the single resource response with the upserted user or an error.
+     */
+    Observable<ResourceResponse<User>> upsertUser(String databaseLink, User user, RequestOptions options);
+
+    /**
+     * Replaces a user.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the replaced user.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param user    the user to use.
+     * @param options the request options.
+     * @return an {@link Observable} containing the single resource response with the replaced user or an error.
+     */
+    Observable<ResourceResponse<User>> replaceUser(User user, RequestOptions options);
+
+    /**
+     * Deletes a user.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response for the deleted user.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param userLink the user link.
+     * @param options  the request options.
+     * @return an {@link Observable} containing the single resource response for the deleted user or an error.
+     */
+    Observable<ResourceResponse<User>> deleteUser(String userLink, RequestOptions options);
+
+    /**
+     * Reads a user.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the read user.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param userLink the user link.
+     * @param options  the request options.
+     * @return an {@link Observable} containing the single resource response with the read user or an error.
+     */
+    Observable<ResourceResponse<User>> readUser(String userLink, RequestOptions options);
+
+    /**
+     * Reads all users in a database.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the read users.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param databaseLink the database link.
+     * @param options      the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the read users or an error.
+     */
+    Observable<FeedResponse<User>> readUsers(String databaseLink, FeedOptions options);
+
+    /**
+     * Query for users.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained users.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param databaseLink the database link.
+     * @param query        the query.
+     * @param options      the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained users or an error.
+     */
+    Observable<FeedResponse<User>> queryUsers(String databaseLink, String query, FeedOptions options);
+
+    /**
+     * Query for users.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained users.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param databaseLink the database link.
+     * @param querySpec    the SQL query specification.
+     * @param options      the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained users or an error.
+     */
+    Observable<FeedResponse<User>> queryUsers(String databaseLink, SqlQuerySpec querySpec, FeedOptions options);
+
+    /**
+     * Creates a permission.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the created permission.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param userLink   the user link.
+     * @param permission the permission to create.
+     * @param options    the request options.
+     * @return an {@link Observable} containing the single resource response with the created permission or an error.
+     */
+    Observable<ResourceResponse<Permission>> createPermission(String userLink, Permission permission, RequestOptions options);
+
+    /**
+     * Upserts a permission.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the upserted permission.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param userLink   the user link.
+     * @param permission the permission to upsert.
+     * @param options    the request options.
+     * @return an {@link Observable} containing the single resource response with the upserted permission or an error.
+     */
+    Observable<ResourceResponse<Permission>> upsertPermission(String userLink, Permission permission, RequestOptions options);
+
+    /**
+     * Replaces a permission.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the replaced permission.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param permission the permission to use.
+     * @param options    the request options.
+     * @return an {@link Observable} containing the single resource response with the replaced permission or an error.
+     */
+    Observable<ResourceResponse<Permission>> replacePermission(Permission permission, RequestOptions options);
+
+    /**
+     * Deletes a permission.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response for the deleted permission.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param permissionLink the permission link.
+     * @param options        the request options.
+     * @return an {@link Observable} containing the single resource response for the deleted permission or an error.
+     */
+    Observable<ResourceResponse<Permission>> deletePermission(String permissionLink, RequestOptions options);
+
+    /**
+     * Reads a permission.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the read permission.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param permissionLink the permission link.
+     * @param options        the request options.
+     * @return an {@link Observable} containing the single resource response with the read permission or an error.
+     */
+    Observable<ResourceResponse<Permission>> readPermission(String permissionLink, RequestOptions options);
+
+    /**
+     * Reads all permissions.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the read permissions.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param permissionLink the permission link.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the read permissions or an error.
+     */
+    Observable<FeedResponse<Permission>> readPermissions(String permissionLink, FeedOptions options);
+
+    /**
+     * Query for permissions.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained permissions.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param permissionLink the permission link.
+     * @param query          the query.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained permissions or an error.
+     */
+    Observable<FeedResponse<Permission>> queryPermissions(String permissionLink, String query, FeedOptions options);
+
+    /**
+     * Query for permissions.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the obtained permissions.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param permissionLink the permission link.
+     * @param querySpec      the SQL query specification.
+     * @param options        the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained permissions or an error.
+     */
+    Observable<FeedResponse<Permission>> queryPermissions(String permissionLink, SqlQuerySpec querySpec, FeedOptions options);
+
+    /**
+     * Replaces an offer.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the replaced offer.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param offer the offer to use.
+     * @return an {@link Observable} containing the single resource response with the replaced offer or an error.
+     */
+    Observable<ResourceResponse<Offer>> replaceOffer(Offer offer);
+
+    /**
+     * Reads an offer.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the read offer.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param offerLink the offer link.
+     * @return an {@link Observable} containing the single resource response with the read offer or an error.
+     */
+    Observable<ResourceResponse<Offer>> readOffer(String offerLink);
+
+    /**
+     * Reads offers.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of the read offers.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param options the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the read offers or an error.
+     */
+    Observable<FeedResponse<Offer>> readOffers(FeedOptions options);
+
+    /**
+     * Query for offers in a database.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of obtained obtained offers.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param query   the query.
+     * @param options the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained offers or an error.
+     */
+    Observable<FeedResponse<Offer>> queryOffers(String query, FeedOptions options);
+
+    /**
+     * Query for offers in a database.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} will contain one or several feed response pages of obtained obtained offers.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @param querySpec the query specification.
+     * @param options   the feed options.
+     * @return an {@link Observable} containing one or several feed response pages of the obtained offers or an error.
+     */
+    Observable<FeedResponse<Offer>> queryOffers(SqlQuerySpec querySpec, FeedOptions options);
+
+    /**
+     * Gets database account information.
+     * <p>
+     * After subscription the operation will be performed.
+     * The {@link Observable} upon successful completion will contain a single resource response with the database account.
+     * In case of failure the {@link Observable} will error.
+     *
+     * @return an {@link Observable} containing the single resource response with the database account or an error.
+     */
+    Observable<DatabaseAccount> getDatabaseAccount();
+
+    /**
+     * Close this {@link CosmosClientInternal} instance and cleans up the resources.
+     */
+    void close();
+
+}

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentClientImpl.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentClientImpl.java
@@ -319,7 +319,9 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
         this.collectionCache = new RxClientCollectionCache(this.sessionContainer, this.gatewayProxy, this, this.retryPolicy);
         this.resetSessionTokenRetryPolicy = new ResetSessionTokenRetryPolicyFactory(this.sessionContainer, this.collectionCache, this.retryPolicy);
 
-        this.partitionKeyRangeCache = new RxPartitionKeyRangeCache(RxDocumentClientImpl.this,
+        Func2<String, FeedOptions, Observable<FeedResponse<PartitionKeyRange>>> readPartitionKeyRangesFunction = 
+                (collLink, feedOptions) -> this.readPartitionKeyRanges(collLink, feedOptions);
+        this.partitionKeyRangeCache = new RxPartitionKeyRangeCache(readPartitionKeyRangesFunction,
                 collectionCache);
 
         if (this.connectionPolicy.getConnectionMode() == ConnectionMode.Gateway) {

--- a/sdk/src/test/java/com/microsoft/azure/cosmos/CosmosTestSuiteBase.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmos/CosmosTestSuiteBase.java
@@ -30,7 +30,6 @@ import com.microsoft.azure.cosmosdb.Resource;
 import com.microsoft.azure.cosmosdb.RetryOptions;
 import com.microsoft.azure.cosmosdb.rx.FailureValidator;
 import com.microsoft.azure.cosmosdb.rx.TestConfigurations;
-import com.microsoft.azure.cosmosdb.rx.internal.RxDocumentClientImpl;
 import io.reactivex.subscribers.TestSubscriber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +49,7 @@ public class CosmosTestSuiteBase {
     protected static final int SETUP_TIMEOUT = 30000;
     protected static final int SHUTDOWN_TIMEOUT = 12000;
     protected static final int SUITE_SETUP_TIMEOUT = 120000;
-    private static final Logger logger = LoggerFactory.getLogger(RxDocumentClientImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(CosmosTestSuiteBase.class);
     
     protected int subscriberValidationTimeout = TIMEOUT;
 


### PR DESCRIPTION
- Removed V3 sdk dependency on AsyncDocumentClient, RxDocumentClientImpl
- Replaced above dependencies with CosmosClientInternal and CosmosClientContext respectively
- Modified RxPartitionkeyRangeCache and ChangeFeedQueryImpl to no longer take any of the clients or client implementations. Instead takes the functions as parameters.
- Made RxGatewayStoreModel and ChangeFeedQueryImpl public so that they can be accessed by V3 SDK package