### PR TITLE
Fixed CODEOWNERs syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,4 @@
 #   https://help.github.com/articles/about-codeowners/  
 
 # Default owner for repo
-*	@moderakh
-*	@christopheranderson
-*	@kushagraThapar
+*	@moderakh @christopheranderson @kushagraThapar


### PR DESCRIPTION
Fixed syntax as per
https://help.github.com/en/articles/about-code-owners#codeowners-syntax