### PR TITLE
Resolved: TCP is now the default direct mode protocol #166.

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -107,10 +107,9 @@
       <artifactId>azure-cosmosdb-commons-test-utils</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative</artifactId>
-      <version>2.0.25.Final</version>
-      <classifier>linux-x86_64</classifier>
+      <groupId>com.beust</groupId>
+      <artifactId>jcommander</artifactId>
+      <version>1.58</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -118,21 +117,35 @@
       <version>${guava.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>${metrics.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-graphite</artifactId>
+      <version>${metrics.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-jvm</artifactId>
+      <version>${metrics.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative</artifactId>
+      <version>${netty-tcnative.version}</version>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+    <dependency>
       <groupId>io.reactivex</groupId>
       <artifactId>rxjava-guava</artifactId>
       <version>1.0.3</version>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
-      <scope>test</scope>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>${log4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -145,40 +158,9 @@
       <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>${log4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>${metrics.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-jvm</artifactId>
-      <version>${metrics.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-graphite</artifactId>
-      <version>${metrics.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.beust</groupId>
-      <artifactId>jcommander</artifactId>
-      <version>1.58</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>${commons-lang3.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <version>${testng.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
@@ -187,9 +169,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito.version}</version>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>${testng.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/commons-test-utils/pom.xml
+++ b/commons-test-utils/pom.xml
@@ -97,29 +97,9 @@ SOFTWARE.
       <artifactId>azure-cosmosdb-commons</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <version>${testng.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>${assertj.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>${slf4j.version}</version>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
@@ -127,9 +107,34 @@ SOFTWARE.
       <version>${log4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>${hamcrest.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>${testng.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/Configs.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/Configs.java
@@ -37,8 +37,8 @@ public class Configs {
     private static final Logger logger = LoggerFactory.getLogger(Configs.class);
     private final SslContext sslContext;
 
-    private static final String PROTOCOL = "COSMOS.PROTOCOL";
-    private static final Protocol DEFAULT_PROTOCOL = Protocol.Https;
+    private static final String PROTOCOL = "cosmos.directModeProtocol";
+    private static final Protocol DEFAULT_PROTOCOL = Protocol.Tcp;
 
     private static final String UNAVAILABLE_LOCATIONS_EXPIRATION_TIME_IN_SECONDS = "COSMOS.UNAVAILABLE_LOCATIONS_EXPIRATION_TIME_IN_SECONDS";
 

--- a/commons/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/ConfigsTests.java
+++ b/commons/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/ConfigsTests.java
@@ -45,7 +45,7 @@ public class ConfigsTests {
     @Test(groups = { "unit" })
     public void getProtocol() {
         Configs config = new Configs();
-        assertThat(config.getProtocol()).isEqualTo(Protocol.valueOf(System.getProperty("COSMOS.PROTOCOL", "Https")));
+        assertThat(config.getProtocol()).isEqualTo(Protocol.valueOf(System.getProperty("cosmos.directModeProtocol", "Tcp")));
     }
 
     @Test(groups = { "unit" })

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -124,15 +124,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/ConflictAPITest.java
+++ b/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/ConflictAPITest.java
@@ -44,6 +44,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
+import static com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient.Builder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -57,7 +58,8 @@ import static org.hamcrest.Matchers.notNullValue;
  * transform an observable to ListenableFuture. Please see
  * {@link #transformObservableToGoogleGuavaListenableFuture()}
  */
-public class ConflictAPITest {
+public class ConflictAPITest extends TestBase {
+
     private final static int TIMEOUT = 60000;
 
     private AsyncDocumentClient client;
@@ -66,14 +68,17 @@ public class ConflictAPITest {
 
     @BeforeClass(groups = "samples", timeOut = TIMEOUT)
     public void setUp() {
+
         ConnectionPolicy connectionPolicy = new ConnectionPolicy();
         connectionPolicy.setConnectionMode(ConnectionMode.Direct);
-        client = new AsyncDocumentClient.Builder()
+
+        builder = new Builder()
                 .withServiceEndpoint(TestConfigurations.HOST)
                 .withMasterKeyOrResourceToken(TestConfigurations.MASTER_KEY)
                 .withConnectionPolicy(connectionPolicy)
-                .withConsistencyLevel(ConsistencyLevel.Session)
-                .build();
+                .withConsistencyLevel(ConsistencyLevel.Session);
+
+        client = builder.build();
 
         DocumentCollection collectionDefinition = new DocumentCollection();
         collectionDefinition.setId(UUID.randomUUID().toString());

--- a/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/DocumentCRUDAsyncAPITest.java
+++ b/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/DocumentCRUDAsyncAPITest.java
@@ -42,7 +42,6 @@ import com.microsoft.azure.cosmosdb.RequestOptions;
 import com.microsoft.azure.cosmosdb.ResourceResponse;
 import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
 import org.apache.commons.lang3.RandomUtils;
-import org.assertj.core.api.Assertions;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -57,6 +56,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
+import static com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient.Builder;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -87,24 +87,29 @@ import static org.hamcrest.Matchers.is;
  * transform an observable to ListenableFuture. Please see
  * {@link #transformObservableToGoogleGuavaListenableFuture()}
  */
-public class DocumentCRUDAsyncAPITest {
+public class DocumentCRUDAsyncAPITest extends TestBase {
+
     private final static String PARTITION_KEY_PATH = "/mypk";
     private final static int TIMEOUT = 60000;
-    private AsyncDocumentClient asyncClient;
+
+    private AsyncDocumentClient client;
     private Database createdDatabase;
     private DocumentCollection createdCollection;
 
     @BeforeClass(groups = "samples", timeOut = TIMEOUT)
     public void setUp() {
+
         // Sets up the requirements for each test
         ConnectionPolicy connectionPolicy = new ConnectionPolicy();
         connectionPolicy.setConnectionMode(ConnectionMode.Direct);
-        asyncClient = new AsyncDocumentClient.Builder()
-                .withServiceEndpoint(TestConfigurations.HOST)
-                .withMasterKeyOrResourceToken(TestConfigurations.MASTER_KEY)
-                .withConnectionPolicy(connectionPolicy)
-                .withConsistencyLevel(ConsistencyLevel.Session)
-                .build();
+
+        this.builder = new Builder()
+            .withServiceEndpoint(TestConfigurations.HOST)
+            .withMasterKeyOrResourceToken(TestConfigurations.MASTER_KEY)
+            .withConnectionPolicy(connectionPolicy)
+            .withConsistencyLevel(ConsistencyLevel.Session);
+
+        this.client = builder.build();
 
         DocumentCollection collectionDefinition = new DocumentCollection();
         collectionDefinition.setId(UUID.randomUUID().toString());
@@ -116,18 +121,18 @@ public class DocumentCRUDAsyncAPITest {
         collectionDefinition.setPartitionKey(partitionKeyDefinition);
 
         // Create database
-        createdDatabase = Utils.createDatabaseForTest(asyncClient);
+        createdDatabase = Utils.createDatabaseForTest(client);
 
         // Create collection
-        createdCollection = asyncClient
-                .createCollection("dbs/" + createdDatabase.getId(), collectionDefinition, null)
-                .toBlocking().single().getResource();
+        createdCollection = client
+            .createCollection("dbs/" + createdDatabase.getId(), collectionDefinition, null)
+            .toBlocking().single().getResource();
     }
 
     @AfterClass(groups = "samples", timeOut = TIMEOUT)
     public void shutdown() {
-        Utils.safeClean(asyncClient, createdDatabase);
-        Utils.safeClose(asyncClient);
+        Utils.safeClean(client, createdDatabase);
+        Utils.safeClose(client);
     }
 
     /**
@@ -136,7 +141,7 @@ public class DocumentCRUDAsyncAPITest {
     @Test(groups = "samples", timeOut = TIMEOUT)
     public void createDocument_Async() throws Exception {
         Document doc = new Document(String.format("{ 'id': 'doc%s', 'counter': '%d'}", UUID.randomUUID().toString(), 1));
-        Observable<ResourceResponse<Document>> createDocumentObservable = asyncClient
+        Observable<ResourceResponse<Document>> createDocumentObservable = client
                 .createDocument(getCollectionLink(), doc, null, true);
 
         final CountDownLatch completionLatch = new CountDownLatch(1);
@@ -162,8 +167,8 @@ public class DocumentCRUDAsyncAPITest {
     @Test(groups = "samples", timeOut = TIMEOUT)
     public void createDocument_Async_withoutLambda() throws Exception {
         Document doc = new Document(String.format("{ 'id': 'doc%s', 'counter': '%d'}", UUID.randomUUID().toString(), 1));
-        Observable<ResourceResponse<Document>> createDocumentObservable = asyncClient
-                .createDocument(getCollectionLink(), doc, null, true);
+        Observable<ResourceResponse<Document>> createDocumentObservable = client
+            .createDocument(getCollectionLink(), doc, null, true);
 
         final CountDownLatch completionLatch = new CountDownLatch(1);
 
@@ -180,14 +185,14 @@ public class DocumentCRUDAsyncAPITest {
 
             public void call(Throwable error) {
                 System.err
-                        .println("an error occurred while creating the document: actual cause: " + error.getMessage());
+                    .println("an error occurred while creating the document: actual cause: " + error.getMessage());
                 completionLatch.countDown();
             }
         };
 
         // Subscribe to Document resource response emitted by the observable
         createDocumentObservable.single() // We know there will be one response
-                .subscribe(onNext, onError);
+                                .subscribe(onNext, onError);
 
         // Wait till document creation completes
         completionLatch.await();
@@ -199,8 +204,8 @@ public class DocumentCRUDAsyncAPITest {
     @Test(groups = "samples", timeOut = TIMEOUT)
     public void createDocument_toBlocking() {
         Document doc = new Document(String.format("{ 'id': 'doc%s', 'counter': '%d'}", UUID.randomUUID().toString(), 1));
-        Observable<ResourceResponse<Document>> createDocumentObservable = asyncClient
-                .createDocument(getCollectionLink(), doc, null, true);
+        Observable<ResourceResponse<Document>> createDocumentObservable = client
+            .createDocument(getCollectionLink(), doc, null, true);
 
         // toBlocking() converts to a blocking observable.
         // single() gets the only result.
@@ -217,13 +222,13 @@ public class DocumentCRUDAsyncAPITest {
         documentDefinition.set("counter", 1);
 
         // Create a document
-        Document createdDocument = asyncClient
-                .createDocument(getCollectionLink(), documentDefinition, null, false).toBlocking().single()
-                .getResource();
+        Document createdDocument = client
+            .createDocument(getCollectionLink(), documentDefinition, null, false).toBlocking().single()
+            .getResource();
 
         // Read the created document
-        Observable<ResourceResponse<Document>> readDocumentObservable = asyncClient
-                .readDocument(getDocumentLink(createdDocument), null);
+        Observable<ResourceResponse<Document>> readDocumentObservable = client
+            .readDocument(getDocumentLink(createdDocument), null);
 
         final CountDownLatch completionLatch = new CountDownLatch(1);
 
@@ -253,8 +258,8 @@ public class DocumentCRUDAsyncAPITest {
         for (int i = 0; i < 10; i++) {
             Document doc = new Document(String.format("{ 'id': 'doc%s', 'counter': '%d'}", UUID.randomUUID().toString(), i));
 
-            Observable<ResourceResponse<Document>> createDocumentObservable = asyncClient
-                    .createDocument(getCollectionLink(), doc, null, false);
+            Observable<ResourceResponse<Document>> createDocumentObservable = client
+                .createDocument(getCollectionLink(), doc, null, false);
             listOfCreateDocumentObservables.add(createDocumentObservable);
         }
 
@@ -264,19 +269,19 @@ public class DocumentCRUDAsyncAPITest {
         // Create a new observable emitting the total charge of creating all 10
         // documents.
         Observable<Double> totalChargeObservable = mergedObservable
-                .map(ResourceResponse::getRequestCharge)
-                // Map to request charge
-                .reduce((totalCharge, charge) -> totalCharge + charge);
+            .map(ResourceResponse::getRequestCharge)
+            // Map to request charge
+            .reduce((totalCharge, charge) -> totalCharge + charge);
         // Sum up all the charges
 
         final CountDownLatch completionLatch = new CountDownLatch(1);
 
         // Subscribe to the total request charge observable
         totalChargeObservable.subscribe(totalCharge -> {
-                                            // Print the total charge
-                                            System.out.println(totalCharge);
-                                            completionLatch.countDown();
-                                        }, e -> completionLatch.countDown()
+                // Print the total charge
+                System.out.println(totalCharge);
+                completionLatch.countDown();
+            }, e -> completionLatch.countDown()
         );
 
         completionLatch.await();
@@ -292,19 +297,19 @@ public class DocumentCRUDAsyncAPITest {
     @Test(groups = "samples", timeOut = TIMEOUT)
     public void createDocument_toBlocking_DocumentAlreadyExists_Fails() {
         Document doc = new Document(String.format("{ 'id': 'doc%s', 'counter': '%d'}", UUID.randomUUID().toString(), 1));
-        asyncClient.createDocument(getCollectionLink(), doc, null, false).toBlocking().single();
+        client.createDocument(getCollectionLink(), doc, null, false).toBlocking().single();
 
         // Create the document
-        Observable<ResourceResponse<Document>> createDocumentObservable = asyncClient
-                .createDocument(getCollectionLink(), doc, null, false);
+        Observable<ResourceResponse<Document>> createDocumentObservable = client
+            .createDocument(getCollectionLink(), doc, null, false);
 
         try {
             createDocumentObservable.toBlocking() // Converts the observable to a blocking observable
-                    .single(); // Gets the single result
+                                    .single(); // Gets the single result
             Assert.fail("Document Already Exists. Document Creation must fail");
         } catch (Exception e) {
             assertThat("Document already exists.", ((DocumentClientException) e.getCause()).getStatusCode(),
-                       equalTo(409));
+                equalTo(409));
         }
     }
 
@@ -318,11 +323,11 @@ public class DocumentCRUDAsyncAPITest {
     @Test(groups = "samples", timeOut = TIMEOUT)
     public void createDocument_Async_DocumentAlreadyExists_Fails() throws Exception {
         Document doc = new Document(String.format("{ 'id': 'doc%s', 'counter': '%d'}", UUID.randomUUID().toString(), 1));
-        asyncClient.createDocument(getCollectionLink(), doc, null, false).toBlocking().single();
+        client.createDocument(getCollectionLink(), doc, null, false).toBlocking().single();
 
         // Create the document
-        Observable<ResourceResponse<Document>> createDocumentObservable = asyncClient
-                .createDocument(getCollectionLink(), doc, null, false);
+        Observable<ResourceResponse<Document>> createDocumentObservable = client
+            .createDocument(getCollectionLink(), doc, null, false);
 
         List<Throwable> errorList = Collections.synchronizedList(new ArrayList<>());
 
@@ -345,17 +350,17 @@ public class DocumentCRUDAsyncAPITest {
     public void documentReplace_Async() throws Exception {
         // Create a document
         Document createdDocument = new Document(String.format("{ 'id': 'doc%s', 'counter': '%d'}", UUID.randomUUID().toString(), 1));
-        createdDocument = asyncClient.createDocument(getCollectionLink(), createdDocument, null, false).toBlocking()
-                .single().getResource();
+        createdDocument = client.createDocument(getCollectionLink(), createdDocument, null, false).toBlocking()
+                                .single().getResource();
 
         // Try to replace the existing document
         Document replacingDocument = new Document(
-                String.format("{ 'id': 'doc%s', 'counter': '%d', 'new-prop' : '2'}", createdDocument.getId(), 1));
-        Observable<ResourceResponse<Document>> replaceDocumentObservable = asyncClient
-                .replaceDocument(getDocumentLink(createdDocument), replacingDocument, null);
+            String.format("{ 'id': 'doc%s', 'counter': '%d', 'new-prop' : '2'}", createdDocument.getId(), 1));
+        Observable<ResourceResponse<Document>> replaceDocumentObservable = client
+            .replaceDocument(getDocumentLink(createdDocument), replacingDocument, null);
 
         List<ResourceResponse<Document>> capturedResponse = Collections
-                .synchronizedList(new ArrayList<>());
+            .synchronizedList(new ArrayList<>());
 
         replaceDocumentObservable.subscribe(resourceResponse -> {
             capturedResponse.add(resourceResponse);
@@ -374,16 +379,16 @@ public class DocumentCRUDAsyncAPITest {
     public void documentUpsert_Async() throws Exception {
         // Create a document
         Document doc = new Document(String.format("{ 'id': 'doc%s', 'counter': '%d'}", UUID.randomUUID().toString(), 1));
-        asyncClient.createDocument(getCollectionLink(), doc, null, false).toBlocking().single();
+        client.createDocument(getCollectionLink(), doc, null, false).toBlocking().single();
 
         // Upsert the existing document
         Document upsertingDocument = new Document(
-                String.format("{ 'id': 'doc%s', 'counter': '%d', 'new-prop' : '2'}", doc.getId(), 1));
-        Observable<ResourceResponse<Document>> upsertDocumentObservable = asyncClient
-                .upsertDocument(getCollectionLink(), upsertingDocument, null, false);
+            String.format("{ 'id': 'doc%s', 'counter': '%d', 'new-prop' : '2'}", doc.getId(), 1));
+        Observable<ResourceResponse<Document>> upsertDocumentObservable = client
+            .upsertDocument(getCollectionLink(), upsertingDocument, null, false);
 
         List<ResourceResponse<Document>> capturedResponse = Collections
-                .synchronizedList(new ArrayList<>());
+            .synchronizedList(new ArrayList<>());
 
         upsertDocumentObservable.subscribe(resourceResponse -> {
             capturedResponse.add(resourceResponse);
@@ -402,14 +407,14 @@ public class DocumentCRUDAsyncAPITest {
     public void documentDelete_Async() throws Exception {
         // Create a document
         Document createdDocument = new Document(String.format("{ 'id': 'doc%s', 'counter': '%d', 'mypk' : '%s'}", UUID.randomUUID().toString(), 1, UUID.randomUUID().toString()));
-        createdDocument = asyncClient.createDocument(getCollectionLink(), createdDocument, null, false).toBlocking()
-                .single().getResource();
+        createdDocument = client.createDocument(getCollectionLink(), createdDocument, null, false).toBlocking()
+                                .single().getResource();
 
         RequestOptions options = new RequestOptions();
         options.setPartitionKey(new PartitionKey(createdDocument.getString("mypk")));
 
         // Delete the existing document
-        Observable<ResourceResponse<Document>> deleteDocumentObservable = asyncClient
+        Observable<ResourceResponse<Document>> deleteDocumentObservable = client
                 .deleteDocument(getDocumentLink(createdDocument), options);
 
         List<ResourceResponse<Document>> capturedResponse = Collections
@@ -426,7 +431,7 @@ public class DocumentCRUDAsyncAPITest {
         // Assert document is deleted
         FeedOptions queryOptions = new FeedOptions();
         queryOptions.setEnableCrossPartitionQuery(true);
-        List<Document> listOfDocuments = asyncClient
+        List<Document> listOfDocuments = client
                 .queryDocuments(getCollectionLink(), String.format("SELECT * FROM r where r.id = '%s'", createdDocument.getId()), queryOptions)
                 .map(FeedResponse::getResults) // Map page to its list of documents
                 .concatMap(Observable::from) // Flatten the observable
@@ -445,13 +450,13 @@ public class DocumentCRUDAsyncAPITest {
     public void documentRead_Async() throws Exception {
         // Create a document
         Document createdDocument = new Document(String.format("{ 'id': 'doc%s', 'counter': '%d', 'mypk' : '%s'}", UUID.randomUUID().toString(), 1, UUID.randomUUID().toString()));
-        createdDocument = asyncClient.createDocument(getCollectionLink(), createdDocument, null, false).toBlocking()
-                .single().getResource();
+        createdDocument = client.createDocument(getCollectionLink(), createdDocument, null, false).toBlocking()
+                                .single().getResource();
 
         // Read the document
         RequestOptions options = new RequestOptions();
         options.setPartitionKey(new PartitionKey(createdDocument.getString("mypk")));
-        Observable<ResourceResponse<Document>> readDocumentObservable = asyncClient
+        Observable<ResourceResponse<Document>> readDocumentObservable = client
                 .readDocument(getDocumentLink(createdDocument), options);
 
         List<ResourceResponse<Document>> capturedResponse = Collections
@@ -491,20 +496,20 @@ public class DocumentCRUDAsyncAPITest {
         String itemAsJsonString = mapper.writeValueAsString(testObject);
         Document doc = new Document(itemAsJsonString);
 
-        Document createdDocument = asyncClient
-                .createDocument(getCollectionLink(), doc, null, false)
-                .toBlocking()
-                .single()
-                .getResource();
+        Document createdDocument = client
+            .createDocument(getCollectionLink(), doc, null, false)
+            .toBlocking()
+            .single()
+            .getResource();
 
         RequestOptions options = new RequestOptions();
         options.setPartitionKey(new PartitionKey(testObject.mypk));
 
-        Document readDocument = asyncClient
-                .readDocument(createdDocument.getSelfLink(), options)
-                .toBlocking()
-                .single()
-                .getResource();
+        Document readDocument = client
+            .readDocument(createdDocument.getSelfLink(), options)
+            .toBlocking()
+            .single()
+            .getResource();
 
         TestObject readObject = mapper.readValue(readDocument.toJson(), TestObject.class);
         assertThat(readObject.prop, equalTo(testObject.prop));
@@ -519,7 +524,7 @@ public class DocumentCRUDAsyncAPITest {
     @Test(groups = "samples", timeOut = TIMEOUT)
     public void transformObservableToGoogleGuavaListenableFuture() throws Exception {
         Document doc = new Document(String.format("{ 'id': 'doc%d', 'counter': '%d'}", RandomUtils.nextInt(), 1));
-        Observable<ResourceResponse<Document>> createDocumentObservable = asyncClient
+        Observable<ResourceResponse<Document>> createDocumentObservable = client
                 .createDocument(getCollectionLink(), doc, null, false);
         ListenableFuture<ResourceResponse<Document>> listenableFuture = ListenableFutureObservable
                 .to(createDocumentObservable);

--- a/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/DocumentQueryAsyncAPITest.java
+++ b/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/DocumentQueryAsyncAPITest.java
@@ -55,6 +55,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient.Builder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -82,33 +83,38 @@ import static org.hamcrest.Matchers.notNullValue;
  * transform an observable to ListenableFuture. Please see
  * {@link #transformObservableToGoogleGuavaListenableFuture()}
  */
-public class DocumentQueryAsyncAPITest {
+public class DocumentQueryAsyncAPITest extends TestBase {
+
     private final static int TIMEOUT = 60000;
-    private AsyncDocumentClient asyncClient;
+
+    private AsyncDocumentClient client;
     private DocumentCollection createdCollection;
     private Database createdDatabase;
     private int numberOfDocuments;
 
     @BeforeClass(groups = "samples", timeOut = TIMEOUT)
     public void setUp() {
+
         ConnectionPolicy connectionPolicy = new ConnectionPolicy();
         connectionPolicy.setConnectionMode(ConnectionMode.Direct);
-        asyncClient = new AsyncDocumentClient.Builder()
+
+        this.builder = new Builder()
                 .withServiceEndpoint(TestConfigurations.HOST)
                 .withMasterKeyOrResourceToken(TestConfigurations.MASTER_KEY)
                 .withConnectionPolicy(connectionPolicy)
-                .withConsistencyLevel(ConsistencyLevel.Session)
-                .build();
+                .withConsistencyLevel(ConsistencyLevel.Session);
+
+        client = this.builder.build();
 
         DocumentCollection collectionDefinition = new DocumentCollection();
         collectionDefinition.setId(UUID.randomUUID().toString());
 
         // Create database
 
-        createdDatabase = Utils.createDatabaseForTest(asyncClient);
+        createdDatabase = Utils.createDatabaseForTest(client);
 
         // Create collection
-        createdCollection = asyncClient
+        createdCollection = client
                 .createCollection("dbs/" + createdDatabase.getId(), collectionDefinition, null)
                 .toBlocking().single().getResource();
 
@@ -116,14 +122,14 @@ public class DocumentQueryAsyncAPITest {
         // Add documents
         for (int i = 0; i < numberOfDocuments; i++) {
             Document doc = new Document(String.format("{ 'id': 'loc%d', 'counter': %d}", i, i));
-            asyncClient.createDocument(getCollectionLink(), doc, null, true).toBlocking().single();
+            client.createDocument(getCollectionLink(), doc, null, true).toBlocking().single();
         }
     }
 
     @AfterClass(groups = "samples", timeOut = TIMEOUT)
     public void shutdown() {
-        Utils.safeClean(asyncClient, createdDatabase);
-        Utils.safeClose(asyncClient);
+        Utils.safeClean(client, createdDatabase);
+        Utils.safeClose(client);
     }
 
     /**
@@ -137,7 +143,7 @@ public class DocumentQueryAsyncAPITest {
         FeedOptions options = new FeedOptions();
         options.setMaxItemCount(requestPageSize);
 
-        Observable<FeedResponse<Document>> documentQueryObservable = asyncClient
+        Observable<FeedResponse<Document>> documentQueryObservable = client
                 .queryDocuments(getCollectionLink(), "SELECT * FROM root", options);
 
         final CountDownLatch mainThreadBarrier = new CountDownLatch(1);
@@ -183,7 +189,7 @@ public class DocumentQueryAsyncAPITest {
         FeedOptions options = new FeedOptions();
         options.setMaxItemCount(requestPageSize);
 
-        Observable<FeedResponse<Document>> documentQueryObservable = asyncClient
+        Observable<FeedResponse<Document>> documentQueryObservable = client
                 .queryDocuments(getCollectionLink(), "SELECT * FROM root", options);
 
         final CountDownLatch mainThreadBarrier = new CountDownLatch(1);
@@ -232,7 +238,7 @@ public class DocumentQueryAsyncAPITest {
         FeedOptions options = new FeedOptions();
         options.setMaxItemCount(requestPageSize);
 
-        Observable<Double> totalChargeObservable = asyncClient
+        Observable<Double> totalChargeObservable = client
                 .queryDocuments(getCollectionLink(), "SELECT * FROM root", options)
                 .map(FeedResponse::getRequestCharge) // Map the page to its request charge
                 .reduce((totalCharge, charge) -> totalCharge + charge); // Sum up all the request charges
@@ -257,7 +263,7 @@ public class DocumentQueryAsyncAPITest {
         FeedOptions options = new FeedOptions();
         options.setMaxItemCount(requestPageSize);
 
-        Observable<FeedResponse<Document>> requestChargeObservable = asyncClient
+        Observable<FeedResponse<Document>> requestChargeObservable = client
                 .queryDocuments(getCollectionLink(), "SELECT * FROM root", options);
 
         AtomicInteger onNextCounter = new AtomicInteger();
@@ -318,11 +324,11 @@ public class DocumentQueryAsyncAPITest {
 
         List<Document> resultList = Collections.synchronizedList(new ArrayList<Document>());
 
-        asyncClient.queryDocuments(getCollectionLink(), "SELECT * FROM root", options)
-                .map(FeedResponse::getResults) // Map the page to the list of documents
-                .concatMap(Observable::from) // Flatten the observable<list<document>> to observable<document>
-                .filter(isPrimeNumber) // Filter documents using isPrimeNumber predicate
-                .subscribe(doc -> resultList.add(doc)); // Collect the results
+        client.queryDocuments(getCollectionLink(), "SELECT * FROM root", options)
+              .map(FeedResponse::getResults) // Map the page to the list of documents
+              .concatMap(Observable::from) // Flatten the observable<list<document>> to observable<document>
+              .filter(isPrimeNumber) // Filter documents using isPrimeNumber predicate
+              .subscribe(doc -> resultList.add(doc)); // Collect the results
 
         Thread.sleep(4000);
 
@@ -360,7 +366,7 @@ public class DocumentQueryAsyncAPITest {
         FeedOptions options = new FeedOptions();
         options.setMaxItemCount(requestPageSize);
 
-        Observable<FeedResponse<Document>> documentQueryObservable = asyncClient
+        Observable<FeedResponse<Document>> documentQueryObservable = client
                 .queryDocuments(getCollectionLink(), "SELECT * FROM root", options);
 
         // Covert the observable to a blocking observable, then convert the blocking
@@ -400,7 +406,7 @@ public class DocumentQueryAsyncAPITest {
 
             Document doc = new Document(String.format("{\"id\":\"documentId%d\",\"key\":\"%s\",\"prop\":%d}", i,
                                                       RandomStringUtils.randomAlphabetic(2), i));
-            asyncClient.createDocument("dbs/" + createdDatabase.getId() + "/colls/" + multiPartitionCollection.getId(),
+            client.createDocument("dbs/" + createdDatabase.getId() + "/colls/" + multiPartitionCollection.getId(),
                                        doc, null, true).toBlocking().single();
         }
 
@@ -415,7 +421,7 @@ public class DocumentQueryAsyncAPITest {
         options.setMaxDegreeOfParallelism(2);
 
         // Get the observable order by query documents
-        Observable<FeedResponse<Document>> documentQueryObservable = asyncClient.queryDocuments(
+        Observable<FeedResponse<Document>> documentQueryObservable = client.queryDocuments(
                 "dbs/" + createdDatabase.getId() + "/colls/" + multiPartitionCollection.getId(), query, options);
 
         List<String> resultList = Collections.synchronizedList(new ArrayList<>());
@@ -449,7 +455,7 @@ public class DocumentQueryAsyncAPITest {
         FeedOptions options = new FeedOptions();
         options.setMaxItemCount(requestPageSize);
 
-        Observable<FeedResponse<Document>> documentQueryObservable = asyncClient
+        Observable<FeedResponse<Document>> documentQueryObservable = client
                 .queryDocuments(getCollectionLink(), "SELECT * FROM root", options);
 
         // Convert to observable of list of pages
@@ -483,8 +489,8 @@ public class DocumentQueryAsyncAPITest {
         DocumentCollection collectionDefinition = new DocumentCollection();
         collectionDefinition.setId(collectionId);
         collectionDefinition.setPartitionKey(partitionKeyDef);
-        DocumentCollection createdCollection = asyncClient.createCollection(databaseLink, collectionDefinition, options)
-                .toBlocking().single().getResource();
+        DocumentCollection createdCollection = client.createCollection(databaseLink, collectionDefinition, options)
+                                                     .toBlocking().single().getResource();
 
         return createdCollection;
     }

--- a/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/InMemoryGroupbyTest.java
+++ b/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/InMemoryGroupbyTest.java
@@ -43,32 +43,36 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
-public class InMemoryGroupbyTest {
+public class InMemoryGroupbyTest extends TestBase {
+
     private final static int TIMEOUT = 60000;
 
-    private static AsyncDocumentClient asyncClient;
-    private static Database createdDatabase;
-    private static DocumentCollection createdCollection;
+    private AsyncDocumentClient client;
+    private Database createdDatabase;
+    private DocumentCollection createdCollection;
 
     @BeforeClass(groups = "samples", timeOut = TIMEOUT)
-    public static void setUp() throws Exception {
+    public void setUp() throws Exception {
+
         ConnectionPolicy connectionPolicy = new ConnectionPolicy();
         connectionPolicy.setConnectionMode(ConnectionMode.Direct);
-        asyncClient = new AsyncDocumentClient.Builder()
+
+        this.builder = new AsyncDocumentClient.Builder()
                 .withServiceEndpoint(TestConfigurations.HOST)
                 .withMasterKeyOrResourceToken(TestConfigurations.MASTER_KEY)
                 .withConnectionPolicy(connectionPolicy)
-                .withConsistencyLevel(ConsistencyLevel.Session)
-                .build();
+                .withConsistencyLevel(ConsistencyLevel.Session);
+
+        this.client = this.builder.build();
 
         // Create database
-        createdDatabase = Utils.createDatabaseForTest(asyncClient);
+        createdDatabase = Utils.createDatabaseForTest(client);
 
         DocumentCollection collectionDefinition = new DocumentCollection();
         collectionDefinition.setId(UUID.randomUUID().toString());
 
         // Create collection
-        createdCollection = asyncClient
+        createdCollection = client
                 .createCollection("dbs/" + createdDatabase.getId(), collectionDefinition, null)
                 .toBlocking().single().getResource();
 
@@ -87,7 +91,7 @@ public class InMemoryGroupbyTest {
                         + "'payer_id': %d, "
                         + " 'created_time' : %d "
                         + "}", UUID.randomUUID().toString(), i, currentTime.getSecond()));
-                asyncClient.createDocument(getCollectionLink(), doc, null, true).toBlocking().single();
+                client.createDocument(getCollectionLink(), doc, null, true).toBlocking().single();
 
                 Thread.sleep(100);
             }
@@ -96,9 +100,9 @@ public class InMemoryGroupbyTest {
     }
 
     @AfterClass(groups = "samples", timeOut = TIMEOUT)
-    public static void shutdown() {
-        Utils.safeClean(asyncClient, createdDatabase);
-        asyncClient.close();
+    public void shutdown() {
+        Utils.safeClean(client, createdDatabase);
+        client.close();
     }
 
     /**
@@ -113,7 +117,7 @@ public class InMemoryGroupbyTest {
         FeedOptions options = new FeedOptions();
         options.setMaxItemCount(requestPageSize);
 
-        Observable<Document> documentsObservable = asyncClient
+        Observable<Document> documentsObservable = client
                 .queryDocuments(getCollectionLink(),
                         new SqlQuerySpec("SELECT * FROM root r WHERE r.site_id=@site_id",
                                 new SqlParameterCollection(new SqlParameter("@site_id", "ABC"))),
@@ -146,7 +150,7 @@ public class InMemoryGroupbyTest {
         options.setMaxItemCount(requestPageSize);
 
 
-        Observable<Document> documentsObservable = asyncClient
+        Observable<Document> documentsObservable = client
                 .queryDocuments(getCollectionLink(),
                         new SqlQuerySpec("SELECT * FROM root r WHERE r.site_id=@site_id",
                                 new SqlParameterCollection(new SqlParameter("@site_id", "ABC"))),
@@ -171,7 +175,7 @@ public class InMemoryGroupbyTest {
         }
     }
 
-    private static  String getCollectionLink() {
-        return "dbs/" + createdDatabase.getId() + "/colls/" + createdCollection.getId();
+    private String getCollectionLink() {
+        return "dbs/" + this.createdDatabase.getId() + "/colls/" + this.createdCollection.getId();
     }
 }

--- a/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/StoredProcedureAsyncAPITest.java
+++ b/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/StoredProcedureAsyncAPITest.java
@@ -50,8 +50,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
-import javax.net.ssl.SSLException;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
@@ -60,35 +58,38 @@ import static org.hamcrest.core.Is.is;
  * This integration test class demonstrates how to use Async API to create
  * and execute Stored Procedures.
  */
-public class StoredProcedureAsyncAPITest {
+public class StoredProcedureAsyncAPITest extends TestBase {
     private final static int TIMEOUT = 60000;
 
+    private AsyncDocumentClient client;
     private Database createdDatabase;
     private DocumentCollection createdCollection;
-    private AsyncDocumentClient asyncClient;
 
     @BeforeClass(groups = "samples", timeOut = TIMEOUT)
     public void setUp() {
+
         ConnectionPolicy connectionPolicy = new ConnectionPolicy();
         connectionPolicy.setConnectionMode(ConnectionMode.Direct);
-        asyncClient = new AsyncDocumentClient.Builder()
+
+        this.builder = new AsyncDocumentClient.Builder()
                 .withServiceEndpoint(TestConfigurations.HOST)
                 .withMasterKeyOrResourceToken(TestConfigurations.MASTER_KEY)
                 .withConnectionPolicy(connectionPolicy)
-                .withConsistencyLevel(ConsistencyLevel.Session)
-                .build();
+                .withConsistencyLevel(ConsistencyLevel.Session);
 
-        createdDatabase = Utils.createDatabaseForTest(asyncClient);
+        this.client = this.builder.build();
 
-        createdCollection = asyncClient
+        createdDatabase = Utils.createDatabaseForTest(client);
+
+        createdCollection = client
                 .createCollection("dbs/" + createdDatabase.getId(), getMultiPartitionCollectionDefinition(), null)
                 .toBlocking().single().getResource();
     }
 
     @AfterClass(groups = "samples", timeOut = TIMEOUT)
     public void shutdown() {
-        Utils.safeClean(asyncClient, createdDatabase);
-        Utils.safeClose(asyncClient);
+        Utils.safeClean(client, createdDatabase);
+        Utils.safeClose(client);
     }
 
     /**
@@ -114,8 +115,8 @@ public class StoredProcedureAsyncAPITest {
                         "    }'" +
                         "}");
 
-        storedProcedure = asyncClient.createStoredProcedure(getCollectionLink(), storedProcedure, null)
-                .toBlocking().single().getResource();
+        storedProcedure = client.createStoredProcedure(getCollectionLink(), storedProcedure, null)
+                                .toBlocking().single().getResource();
 
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.setScriptLoggingEnabled(true);
@@ -124,8 +125,8 @@ public class StoredProcedureAsyncAPITest {
         final CountDownLatch successfulCompletionLatch = new CountDownLatch(1);
 
         // Execute the stored procedure
-        asyncClient.executeStoredProcedure(getSprocLink(storedProcedure), requestOptions, new Object[]{})
-                .subscribe(storedProcedureResponse -> {
+        client.executeStoredProcedure(getSprocLink(storedProcedure), requestOptions, new Object[]{})
+              .subscribe(storedProcedureResponse -> {
                     String logResult = "The value of x is 1.";
                     try {
                         assertThat(URLDecoder.decode(storedProcedureResponse.getScriptLog(), "UTF-8"), is(logResult));
@@ -160,8 +161,8 @@ public class StoredProcedureAsyncAPITest {
                         "    }'" +
                         "}");
 
-        storedProcedure = asyncClient.createStoredProcedure(getCollectionLink(), storedProcedure, null)
-                .toBlocking().single().getResource();
+        storedProcedure = client.createStoredProcedure(getCollectionLink(), storedProcedure, null)
+                                .toBlocking().single().getResource();
 
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.setPartitionKey(new PartitionKey("Seattle"));
@@ -170,8 +171,8 @@ public class StoredProcedureAsyncAPITest {
 
         // Execute the stored procedure
         Object[] storedProcedureArgs = new Object[]{"a", 123};
-        asyncClient.executeStoredProcedure(getSprocLink(storedProcedure), requestOptions, storedProcedureArgs)
-                .subscribe(storedProcedureResponse -> {
+        client.executeStoredProcedure(getSprocLink(storedProcedure), requestOptions, storedProcedureArgs)
+              .subscribe(storedProcedureResponse -> {
                     String storedProcResultAsString = storedProcedureResponse.getResponseAsString();
                     assertThat(storedProcResultAsString, equalTo("\"2*a is 246\""));
                     successfulCompletionLatch.countDown();
@@ -200,8 +201,8 @@ public class StoredProcedureAsyncAPITest {
                         "    }'" +
                         "}");
 
-        storedProcedure = asyncClient.createStoredProcedure(getCollectionLink(), storedProcedure, null)
-                .toBlocking().single().getResource();
+        storedProcedure = client.createStoredProcedure(getCollectionLink(), storedProcedure, null)
+                                .toBlocking().single().getResource();
 
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.setPartitionKey(new PartitionKey("Seattle"));
@@ -216,8 +217,8 @@ public class StoredProcedureAsyncAPITest {
 
         // Execute the stored procedure
         Object[] storedProcedureArgs = new Object[]{samplePojo};
-        asyncClient.executeStoredProcedure(getSprocLink(storedProcedure), requestOptions, storedProcedureArgs)
-                .subscribe(storedProcedureResponse -> {
+        client.executeStoredProcedure(getSprocLink(storedProcedure), requestOptions, storedProcedureArgs)
+              .subscribe(storedProcedureResponse -> {
                     String storedProcResultAsString = storedProcedureResponse.getResponseAsString();
                     assertThat(storedProcResultAsString, equalTo("\"a is my temp value\""));
                     successfulCompletionLatch.countDown();

--- a/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/TestBase.java
+++ b/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/TestBase.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.azure.cosmosdb.rx.examples;
+
+import com.google.common.base.Strings;
+import com.microsoft.azure.cosmosdb.ConnectionMode;
+import org.testng.ITest;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+import java.lang.reflect.Method;
+
+import static com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient.Builder;
+
+public class TestBase implements ITest {
+
+    Builder builder;
+    private String testName;
+
+    @Override
+    public final String getTestName() {
+        return this.testName;
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    final void setTestName(Method method) {
+
+        String connectionMode = builder.getConnectionPolicy().getConnectionMode() == ConnectionMode.Direct
+            ? "Direct " + builder.getConfigs().getProtocol().name().toUpperCase()
+            : "Gateway";
+
+        this.testName = Strings.lenientFormat("%s::%s[%s with %s consistency]",
+            method.getDeclaringClass().getSimpleName(),
+            method.getName(),
+            connectionMode,
+            builder.getDesiredConsistencyLevel());
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public final void unsetTestName() {
+        this.testName = null;
+    }
+}

--- a/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/TokenResolverTest.java
+++ b/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/TokenResolverTest.java
@@ -173,7 +173,9 @@ public class TokenResolverTest extends TestBase {
                     capturedResponse.add(resourceResponse);
                 });
             }
-            Thread.sleep(2000);
+            // TODO: DANOBLE: Reduce wait time to 2 seconds.
+            //   link: [Direct TCP: Implement health check requests #119](https://github.com/Azure/azure-cosmosdb-java/issues/119)
+            Thread.sleep(8 * 2000);
             System.out.println("capturedResponse.size() = " + capturedResponse.size());
             assertThat(capturedResponse, hasSize(10));
         } finally {
@@ -214,7 +216,9 @@ public class TokenResolverTest extends TestBase {
                     capturedResponse.add(resourceResponse);
                 });
             }
-            Thread.sleep(2000);
+            // TODO: DANOBLE: Reduce wait time to 2 seconds.
+            //  link: [Direct TCP: Implement health check requests #119](https://github.com/Azure/azure-cosmosdb-java/issues/119)
+            Thread.sleep(8 * 2000);
             assertThat(capturedResponse, hasSize(10));
         } finally {
             Utils.safeClose(asyncClientWithTokenResolver);

--- a/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/TokenResolverTest.java
+++ b/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/TokenResolverTest.java
@@ -51,14 +51,16 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
-public class TokenResolverTest {
+public class TokenResolverTest extends TestBase {
+
     private final static int TIMEOUT = 60000;
     private final static String USER_ID = "userId";
-    private AsyncDocumentClient asyncClient;
+
+    private AsyncDocumentClient client;
     private Database createdDatabase;
     private DocumentCollection createdCollection;
     private Map<String, String> userToReadOnlyResourceTokenMap = new HashMap<>();
@@ -74,24 +76,26 @@ public class TokenResolverTest {
      */
     @BeforeClass(groups = "samples", timeOut = TIMEOUT)
     public void setUp() {
-        // Sets up the requirements for each test
+
         ConnectionPolicy connectionPolicy = new ConnectionPolicy();
         connectionPolicy.setConnectionMode(ConnectionMode.Direct);
-        asyncClient = new AsyncDocumentClient.Builder()
+
+        this.builder = new AsyncDocumentClient.Builder()
                 .withServiceEndpoint(TestConfigurations.HOST)
                 .withMasterKeyOrResourceToken(TestConfigurations.MASTER_KEY)
                 .withConnectionPolicy(connectionPolicy)
-                .withConsistencyLevel(ConsistencyLevel.Session)
-                .build();
+                .withConsistencyLevel(ConsistencyLevel.Session);
+
+        this.client = this.builder.build();
 
         DocumentCollection collectionDefinition = new DocumentCollection();
         collectionDefinition.setId(UUID.randomUUID().toString());
 
         // Create database
-        createdDatabase = Utils.createDatabaseForTest(asyncClient);
+        createdDatabase = Utils.createDatabaseForTest(client);
 
         // Create collection
-        createdCollection = asyncClient
+        createdCollection = client
                 .createCollection("dbs/" + createdDatabase.getId(), collectionDefinition, null)
                 .toBlocking().single().getResource();
 
@@ -99,12 +103,12 @@ public class TokenResolverTest {
             // Create a document
             Document documentDefinition = new Document();
             documentDefinition.setId(UUID.randomUUID().toString());
-            Document createdDocument = asyncClient.createDocument(createdCollection.getSelfLink(), documentDefinition, null, true).toBlocking().first().getResource();
+            Document createdDocument = client.createDocument(createdCollection.getSelfLink(), documentDefinition, null, true).toBlocking().first().getResource();
 
             // Create a User who is meant to only read this document
             User readUserDefinition = new User();
             readUserDefinition.setId(UUID.randomUUID().toString());
-            User createdReadUser = asyncClient.createUser(createdDatabase.getSelfLink(), readUserDefinition, null).toBlocking().first().getResource();
+            User createdReadUser = client.createUser(createdDatabase.getSelfLink(), readUserDefinition, null).toBlocking().first().getResource();
 
             // Create a read only permission for  the above document
             Permission readOnlyPermissionDefinition = new Permission();
@@ -113,7 +117,7 @@ public class TokenResolverTest {
             readOnlyPermissionDefinition.setPermissionMode(PermissionMode.Read);
 
             // Assign the permission to the above user
-            Permission readOnlyCreatedPermission = asyncClient.createPermission(createdReadUser.getSelfLink(), readOnlyPermissionDefinition, null).toBlocking().first().getResource();
+            Permission readOnlyCreatedPermission = client.createPermission(createdReadUser.getSelfLink(), readOnlyPermissionDefinition, null).toBlocking().first().getResource();
             userToReadOnlyResourceTokenMap.put(createdReadUser.getId(), readOnlyCreatedPermission.getToken());
 
             documentToReadUserMap.put(createdDocument.getSelfLink(), createdReadUser.getId());
@@ -121,7 +125,7 @@ public class TokenResolverTest {
             // Create a User who can both read and write this document
             User readWriteUserDefinition = new User();
             readWriteUserDefinition.setId(UUID.randomUUID().toString());
-            User createdReadWriteUser = asyncClient.createUser(createdDatabase.getSelfLink(), readWriteUserDefinition, null).toBlocking().first().getResource();
+            User createdReadWriteUser = client.createUser(createdDatabase.getSelfLink(), readWriteUserDefinition, null).toBlocking().first().getResource();
 
             // Create a read/write permission for the above document
             Permission readWritePermissionDefinition = new Permission();
@@ -130,7 +134,7 @@ public class TokenResolverTest {
             readWritePermissionDefinition.setPermissionMode(PermissionMode.All);
 
             // Assign the permission to the above user
-            Permission readWriteCreatedPermission = asyncClient.createPermission(createdReadWriteUser.getSelfLink(), readWritePermissionDefinition, null).toBlocking().first().getResource();
+            Permission readWriteCreatedPermission = client.createPermission(createdReadWriteUser.getSelfLink(), readWritePermissionDefinition, null).toBlocking().first().getResource();
             userToReadWriteResourceTokenMap.put(createdReadWriteUser.getId(), readWriteCreatedPermission.getToken());
 
             documentToReadWriteUserMap.put(createdDocument.getSelfLink(), createdReadWriteUser.getId());
@@ -330,7 +334,7 @@ public class TokenResolverTest {
 
     @AfterClass(groups = "samples", timeOut = TIMEOUT)
     public void shutdown() {
-        Utils.safeClean(asyncClient, createdDatabase);
-        Utils.safeClose(asyncClient);
+        Utils.safeClean(client, createdDatabase);
+        Utils.safeClose(client);
     }
 }

--- a/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/UniqueIndexAsyncAPITest.java
+++ b/examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/UniqueIndexAsyncAPITest.java
@@ -47,7 +47,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
-public class UniqueIndexAsyncAPITest {
+public class UniqueIndexAsyncAPITest extends TestBase {
+
     private final static int TIMEOUT = 60000;
 
     private AsyncDocumentClient client;
@@ -90,15 +91,17 @@ public class UniqueIndexAsyncAPITest {
 
     @BeforeClass(groups = "samples", timeOut = TIMEOUT)
     public void setUp() {
-        // Sets up the requirements for each test
+
         ConnectionPolicy connectionPolicy = new ConnectionPolicy();
         connectionPolicy.setConnectionMode(ConnectionMode.Direct);
-        client = new AsyncDocumentClient.Builder()
+
+        this.builder = new AsyncDocumentClient.Builder()
                 .withServiceEndpoint(TestConfigurations.HOST)
                 .withMasterKeyOrResourceToken(TestConfigurations.MASTER_KEY)
                 .withConnectionPolicy(connectionPolicy)
-                .withConsistencyLevel(ConsistencyLevel.Session)
-                .build();
+                .withConsistencyLevel(ConsistencyLevel.Session);
+
+        this.client = this.builder.build();
 
         DocumentCollection collectionDefinition = new DocumentCollection();
         collectionDefinition.setId(UUID.randomUUID().toString());

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -101,12 +101,6 @@ SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>${slf4j.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,14 @@
     <commons-lang3.version>3.8.1</commons-lang3.version>
     <commons-text.version>1.6</commons-text.version>
     <guava.version>27.0.1-jre</guava.version>
+    <hamcrest.version>1.3</hamcrest.version>
     <jackson-databind.version>2.9.9</jackson-databind.version>
     <java-uuid-generator.version>3.1.4</java-uuid-generator.version>
     <log4j.version>1.2.17</log4j.version>
     <metrics.version>4.0.5</metrics.version>
     <mockito.version>1.10.19</mockito.version>
     <netty.version>4.1.36.Final</netty.version>
+    <netty-tcnative.version>2.0.25.Final</netty-tcnative.version>
     <rxjava-extras.version>0.8.0.17</rxjava-extras.version>
     <rxjava-string.version>1.1.1</rxjava-string.version>
     <rxjava.version>1.3.8</rxjava.version>

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/DocumentClientResourceLeakTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/DocumentClientResourceLeakTest.java
@@ -25,9 +25,7 @@ package com.microsoft.azure.cosmosdb.rx;
 import com.microsoft.azure.cosmosdb.Database;
 import com.microsoft.azure.cosmosdb.Document;
 import com.microsoft.azure.cosmosdb.DocumentCollection;
-import com.microsoft.azure.cosmosdb.internal.directconnectivity.Protocol;
 import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient.Builder;
-import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
@@ -39,9 +37,9 @@ import static org.apache.commons.io.FileUtils.ONE_MB;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DocumentClientResourceLeakTest extends TestSuiteBase {
+
     private static final int TIMEOUT = 240000;
     private static final int MAX_NUMBER = 1000;
-    private Builder clientBuilder;
     private AsyncDocumentClient client;
 
     private Database createdDatabase;
@@ -54,31 +52,34 @@ public class DocumentClientResourceLeakTest extends TestSuiteBase {
 
     @Test(groups = {"emulator"}, timeOut = TIMEOUT)
     public void resourceLeak() throws Exception {
-        //TODO FIXME DANOBLE this test doesn't pass on RNTBD
-        if (clientBuilder.configs.getProtocol() == Protocol.Tcp) {
-            throw new SkipException("RNTBD");
-        }
+
         System.gc();
         TimeUnit.SECONDS.sleep(10);
         long usedMemoryInBytesBefore = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory());
 
-
         for (int i = 0; i < MAX_NUMBER; i++) {
-            logger.info("client {}", i);
+            logger.info("CLIENT {}", i);
             client = clientBuilder.build();
             try {
-                logger.info("creating doc...");
+                logger.info("creating document");
                 createDocument(client, createdDatabase.getId(), createdCollection.getId(), getDocumentDefinition());
             } finally {
-                logger.info("closing client...");
+                logger.info("closing client");
                 client.close();
             }
         }
+
         System.gc();
         TimeUnit.SECONDS.sleep(10);
+
         long usedMemoryInBytesAfter = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory());
 
-        assertThat(usedMemoryInBytesAfter - usedMemoryInBytesBefore).isLessThan(200 * ONE_MB);
+        logger.info("Memory delta: {} - {} = {} MB",
+            usedMemoryInBytesAfter / (double)ONE_MB,
+            usedMemoryInBytesBefore / (double)ONE_MB,
+            (usedMemoryInBytesAfter - usedMemoryInBytesBefore) / (double)ONE_MB);
+
+        assertThat(usedMemoryInBytesAfter - usedMemoryInBytesBefore).isLessThan(275 * ONE_MB);
     }
 
     @BeforeClass(groups = {"emulator"}, timeOut = SETUP_TIMEOUT)

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/DocumentClientResourceLeakTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/DocumentClientResourceLeakTest.java
@@ -50,7 +50,7 @@ public class DocumentClientResourceLeakTest extends TestSuiteBase {
         this.clientBuilder = clientBuilder;
     }
 
-    @Test(groups = {"emulator"}, timeOut = TIMEOUT)
+    @Test(groups = {"emulator"}, timeOut = 2 * TIMEOUT)
     public void resourceLeak() throws Exception {
 
         System.gc();

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TestSuiteBase.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TestSuiteBase.java
@@ -138,14 +138,22 @@ public class TestSuiteBase {
 
     @BeforeMethod(groups = {"simple", "long", "direct", "multi-master", "emulator", "non-emulator"})
     public void beforeMethod(Method method) {
+
         if (this.clientBuilder != null) {
+
+            ConnectionMode connectionMode = this.clientBuilder.connectionPolicy.getConnectionMode();
+            Protocol protocol = connectionMode == ConnectionMode.Direct ? this.clientBuilder.configs.getProtocol() : Protocol.Https;
+
             logger.info("Starting {}::{} using {} {} mode with {} consistency",
-                        method.getDeclaringClass().getSimpleName(), method.getName(),
-                        this.clientBuilder.connectionPolicy.getConnectionMode(),
-                        this.clientBuilder.configs.getProtocol(),
-                        this.clientBuilder.desiredConsistencyLevel);
+                method.getDeclaringClass().getSimpleName(),
+                method.getName(),
+                connectionMode,
+                protocol,
+                this.clientBuilder.desiredConsistencyLevel
+            );
             return;
         }
+
         logger.info("Starting {}::{}", method.getDeclaringClass().getSimpleName(), method.getName());
     }
 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/SpyClientUnderTestFactory.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/SpyClientUnderTestFactory.java
@@ -84,7 +84,6 @@ public class SpyClientUnderTestFactory {
 
         ClientWithGatewaySpy(URI serviceEndpoint, String masterKey, ConnectionPolicy connectionPolicy, ConsistencyLevel consistencyLevel, Configs configs) {
             super(serviceEndpoint, masterKey, connectionPolicy, consistencyLevel, configs);
-            assert connectionPolicy.getConnectionMode() == ConnectionMode.Gateway;
             init();
         }
 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/SpyClientUnderTestFactory.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/SpyClientUnderTestFactory.java
@@ -28,6 +28,7 @@ import com.microsoft.azure.cosmosdb.ConsistencyLevel;
 import com.microsoft.azure.cosmosdb.ISessionContainer;
 import com.microsoft.azure.cosmosdb.internal.QueryCompatibilityMode;
 import com.microsoft.azure.cosmosdb.internal.UserAgentContainer;
+import com.microsoft.azure.cosmosdb.internal.directconnectivity.Protocol;
 import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
 import com.microsoft.azure.cosmosdb.rx.SpyClientBuilder;
 import com.microsoft.azure.cosmosdb.rx.internal.directconnectivity.ReflectionUtils;
@@ -52,6 +53,7 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 public class SpyClientUnderTestFactory {
 
@@ -64,6 +66,12 @@ public class SpyClientUnderTestFactory {
         public abstract List<T> getCapturedRequests();
         
         public abstract void clearCapturedRequests();
+
+        protected static Configs createConfigsSpy(final Protocol protocol) {
+            final Configs configs = spy(new Configs());
+            doAnswer((Answer<Protocol>) invocation -> protocol).when(configs).getProtocol();
+            return configs;
+        }
     }
     
     public static class ClientWithGatewaySpy extends SpyBaseClass<RxDocumentServiceRequest> {
@@ -76,6 +84,7 @@ public class SpyClientUnderTestFactory {
 
         ClientWithGatewaySpy(URI serviceEndpoint, String masterKey, ConnectionPolicy connectionPolicy, ConsistencyLevel consistencyLevel, Configs configs) {
             super(serviceEndpoint, masterKey, connectionPolicy, consistencyLevel, configs);
+            assert connectionPolicy.getConnectionMode() == ConnectionMode.Gateway;
             init();
         }
 
@@ -99,7 +108,7 @@ public class SpyClientUnderTestFactory {
                     globalEndpointManager,
                     rxClient);
             this.requests = Collections.synchronizedList(new ArrayList<>());
-            this.spyRxGatewayStoreModel = Mockito.spy(this.origRxGatewayStoreModel);
+            this.spyRxGatewayStoreModel = spy(this.origRxGatewayStoreModel);
             this.initRequestCapture();
             return this.spyRxGatewayStoreModel;
         }
@@ -198,12 +207,11 @@ public class SpyClientUnderTestFactory {
                 Collections.synchronizedList(new ArrayList<Pair<HttpClientRequest<ByteBuf>, Future<HttpResponseHeaders>>>());
 
         DirectHttpsClientUnderTest(URI serviceEndpoint, String masterKey, ConnectionPolicy connectionPolicy, ConsistencyLevel consistencyLevel) {
-            // TODO: DANOBLE: ensure the configs instance instantiated here specifies Protocol.Https
-            super(serviceEndpoint, masterKey, connectionPolicy, consistencyLevel, new Configs());
+            super(serviceEndpoint, masterKey, connectionPolicy, consistencyLevel, createConfigsSpy(Protocol.Https));
             assert connectionPolicy.getConnectionMode() == ConnectionMode.Direct;
             init();
             this.origHttpClient = ReflectionUtils.getDirectHttpsHttpClient(this);
-            this.spyHttpClient = Mockito.spy(this.origHttpClient);
+            this.spyHttpClient = spy(this.origHttpClient);
             ReflectionUtils.setDirectHttpsHttpClient(this, this.spyHttpClient);
             this.initRequestCapture(this.spyHttpClient);
         }
@@ -292,7 +300,7 @@ public class SpyClientUnderTestFactory {
                                                      GlobalEndpointManager globalEndpointManager,
                                                      CompositeHttpClient<ByteBuf, ByteBuf> rxClient) {
 
-                CompositeHttpClient<ByteBuf, ByteBuf> spyClient = Mockito.spy(rxClient);
+                CompositeHttpClient<ByteBuf, ByteBuf> spyClient = spy(rxClient);
 
                 this.origHttpClient = rxClient;
                 this.spyHttpClient = spyClient;


### PR DESCRIPTION
**TODO:**

- [X] Address `DirectHttpsClientUnderTest` issue described by @moderakh below.
   `DirectHttpsClientUnderTest` now ensures that the HTTPS protocol is used.

- [X] Track down other cases where tests assume the default protocol is HTTPS.
  Confirmed: no test failures that are the result of assuming the default protocol is HTTPS.

**Also found and fixed:** A dependency issue introduced by our use of `mockito` and `hamcrest` as illustrated here:
```
com.microsoft.azure:azure-cosmosdb-examples:jar:2.4.5
+- org.mockito:mockito-core:jar:1.10.19:test
|  \- org.hamcrest:hamcrest-core:jar:1.1:test
\- org.hamcrest:hamcrest-all:jar:1.3:test
```
See the pom.xml changes and run this command to verify the fix.
```
mvn dependency:tree -Dverbose -Dincludes=org.hamcrest
```
This issue has also been addressed for v3 on this branch: `danoble/rntbd/v3` and `danoble/rntbd/repeat-v3`
