### PR TITLE
artifact renaming, versioning update, and jar collection command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ docs
 target
 bin
 test-output
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Java SDK for SQL API of Azure Cosmos DB
+
 [![Maven Central](https://img.shields.io/maven-central/v/com.microsoft.azure/azure-cosmosdb.svg)](https://search.maven.org/artifact/com.microsoft.azure/azure-cosmosdb/2.4.3/jar)
 [![Build Status](https://api.travis-ci.org/Azure/azure-cosmosdb-java.svg?branch=master)](https://travis-ci.org/Azure/azure-cosmosdb-java)
 [![Known Vulnerabilities](https://snyk.io/test/github/Azure/azure-cosmosdb-java/badge.svg?targetFile=sdk%2Fpom.xml)](https://snyk.io/test/github/Azure/azure-cosmosdb-java?targetFile=sdk%2Fpom.xml)
+
 <!--[![Coverage Status](https://img.shields.io/codecov/c/github/Azure/azure-cosmosdb-java.svg)](https://codecov.io/gh/Azure/azure-cosmosdb-java)
 ![](https://img.shields.io/github/issues/azure/azure-cosmosdb-java.svg)
  -->
- 
+
 <!-- TOC depthFrom:2 depthTo:2 withLinks:1 updateOnSave:1 orderedList:0 -->
 
 - [Consuming the official Microsoft Azure Cosmos DB Java SDK](#consuming-the-official-microsoft-azure-cosmos-db-java-sdk)
@@ -22,13 +24,12 @@
 
 <!-- /TOC -->
 
-
 ## Consuming the official Microsoft Azure Cosmos DB Java SDK
 
 This project provides a SDK library in Java for interacting with [SQL API](https://docs.microsoft.com/en-us/azure/cosmos-db/sql-api-sql-query) of [Azure Cosmos DB
 Database Service](https://azure.microsoft.com/en-us/services/cosmos-db/). This project also includes samples, tools, and utilities.
 
-Jar dependency binary information for maven and gradle can be found here at [maven]( https://mvnrepository.com/artifact/com.microsoft.azure/azure-cosmosdb/2.4.3).
+Jar dependency binary information for maven and gradle can be found here at [maven](https://mvnrepository.com/artifact/com.microsoft.azure/azure-cosmosdb/2.4.3).
 
 For example, using maven, you can add the following dependency to your maven pom file:
 
@@ -40,35 +41,35 @@ For example, using maven, you can add the following dependency to your maven pom
 </dependency>
 ```
 
-
-
 Useful links:
+
 - [Sample Get Started APP](https://github.com/Azure-Samples/azure-cosmos-db-sql-api-async-java-getting-started)
-- [Introduction to Resource Model of Azure Cosmos DB Service]( https://docs.microsoft.com/en-us/azure/cosmos-db/sql-api-resources)
+- [Introduction to Resource Model of Azure Cosmos DB Service](https://docs.microsoft.com/en-us/azure/cosmos-db/sql-api-resources)
 - [Introduction to SQL API of Azure Cosmos DB Service](https://docs.microsoft.com/en-us/azure/cosmos-db/sql-api-sql-query)
 - [SDK JavaDoc API](https://azure.github.io/azure-cosmosdb-java/2.4.0/com/microsoft/azure/cosmosdb/rx/AsyncDocumentClient.html)
 - [RxJava Observable JavaDoc API](http://reactivex.io/RxJava/1.x/javadoc/rx/Observable.html)
 - [SDK FAQ](faq/)
 
 ## Prerequisites
-* Java Development Kit 8
-* An active Azure account. If you don't have one, you can sign up for a [free account](https://azure.microsoft.com/free/). Alternatively, you can use the [Azure Cosmos DB Emulator](https://azure.microsoft.com/documentation/articles/documentdb-nosql-local-emulator) for development and testing. As emulator https certificate is self signed, you need to import its certificate to java trusted cert store as [explained here](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator-export-ssl-certificates)
-* (Optional) SLF4J is a logging facade.
-* (Optional) [SLF4J binding](http://www.slf4j.org/manual.html) is used to associate a specific logging framework with SLF4J.
-* (Optional) Maven
+
+- Java Development Kit 8
+- An active Azure account. If you don't have one, you can sign up for a [free account](https://azure.microsoft.com/free/). Alternatively, you can use the [Azure Cosmos DB Emulator](https://azure.microsoft.com/documentation/articles/documentdb-nosql-local-emulator) for development and testing. As emulator https certificate is self signed, you need to import its certificate to java trusted cert store as [explained here](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator-export-ssl-certificates)
+- (Optional) SLF4J is a logging facade.
+- (Optional) [SLF4J binding](http://www.slf4j.org/manual.html) is used to associate a specific logging framework with SLF4J.
+- (Optional) Maven
 
 SLF4J is only needed if you plan to use logging, please also download an SLF4J binding which will link the SLF4J API with the logging implementation of your choice. See the [SLF4J user manual](http://www.slf4j.org/manual.html) for more information.
 
-
 ## API Documentation
+
 Javadoc is available [here](https://azure.github.io/azure-cosmosdb-java/2.4.0/com/microsoft/azure/cosmosdb/rx/AsyncDocumentClient.html).
 
 The SDK provide Reactive Extension Observable based async API. You can read more about RxJava and [Observable APIs here](http://reactivex.io/RxJava/1.x/javadoc/rx/Observable.html).
 
-
 ## Usage Code Sample
 
 Code Sample for creating a Document:
+
 ```java
 import com.microsoft.azure.cosmosdb.rx.*;
 import com.microsoft.azure.cosmosdb.*;
@@ -104,17 +105,17 @@ We have a get started sample app available [here](https://github.com/Azure-Sampl
 
 Also We have more examples in form of standalone unit tests in [examples project](examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples).
 
-
 ## Guide for Prod
+
 To achieve better performance and higher throughput there are a few tips that are helpful to follow:
 
 ### Use Appropriate Scheduler (Avoid stealing Eventloop IO Netty threads)
+
 SDK uses [netty](https://netty.io/) for non-blocking IO. The SDK uses a fixed number of IO netty eventloop threads (as many CPU cores your machine has) for executing IO operations.
 
- The Observable returned by API emits the result on one of the shared IO eventloop netty threads. So it is important to not block the shared IO eventloop netty threads. Doing CPU intensive work or blocking operation on the IO eventloop netty thread may cause deadlock or significantly reduce SDK throughput.
+The Observable returned by API emits the result on one of the shared IO eventloop netty threads. So it is important to not block the shared IO eventloop netty threads. Doing CPU intensive work or blocking operation on the IO eventloop netty thread may cause deadlock or significantly reduce SDK throughput.
 
 For example the following code executes a cpu intensive work on the eventloop IO netty thread:
-
 
 ```java
 Observable<ResourceResponse<Document>> createDocObs = asyncDocumentClient.createDocument(
@@ -150,18 +151,19 @@ subscribe(
 ```
 
 Based on the type of your work you should use the appropriate existing RxJava Scheduler for your work. Please read here
-[``Schedulers``](http://reactivex.io/RxJava/1.x/javadoc/rx/schedulers/Schedulers.html).
-
+[`Schedulers`](http://reactivex.io/RxJava/1.x/javadoc/rx/schedulers/Schedulers.html).
 
 ### Disable netty's logging
+
 Netty library logging is very chatty and need to be turned off (suppressing log in the configuration may not be enough) to avoid additional CPU costs.
-If you are not in debugging mode disable netty's logging altogether. So if you are using log4j to remove the additional CPU costs incurred by ``org.apache.log4j.Category.callAppenders()`` from netty add the following line to your codebase:
+If you are not in debugging mode disable netty's logging altogether. So if you are using log4j to remove the additional CPU costs incurred by `org.apache.log4j.Category.callAppenders()` from netty add the following line to your codebase:
 
 ```java
 org.apache.log4j.Logger.getLogger("io.netty").setLevel(org.apache.log4j.Level.OFF);
 ```
 
 ### OS Open files Resource Limit
+
 Some Linux systems (like Redhat) have an upper limit on the number of open files and so the total number of connections. Run the following to view the current limits:
 
 ```bash
@@ -175,6 +177,7 @@ Open the limits.conf file:
 ```bash
 vim /etc/security/limits.conf
 ```
+
 Add/modify the following lines:
 
 ```
@@ -182,16 +185,19 @@ Add/modify the following lines:
 ```
 
 ### Use native SSL implementation for netty
+
 Netty can use OpenSSL directly for SSL implementation stack to achieve better performance.
 In the absence of this configuration netty will fall back to Java's default SSL implementation.
 
 on Ubuntu:
+
 ```bash
 sudo apt-get install openssl
 sudo apt-get install libapr1
 ```
 
 and add the following dependency to your project maven dependencies:
+
 ```xml
 <dependency>
   <groupId>io.netty</groupId>
@@ -204,14 +210,14 @@ and add the following dependency to your project maven dependencies:
 For other platforms (Redhat, Windows, Mac, etc) please refer to these instructions https://netty.io/wiki/forked-tomcat-native.html
 
 ### Common Perf Tips
+
 There is a set of common perf tips written for our sync SDK. The majority of them also apply to the async SDK. It is available [here](https://docs.microsoft.com/en-us/azure/cosmos-db/performance-tips-java).
 
 ## Future, CompletableFuture, and ListenableFuture
 
 The SDK provide Reactive Extension (Rx) [Observable](http://reactivex.io/RxJava/1.x/javadoc/rx/Observable.html) based async API.
 
-
-RX API has advantages over Future based APIs. But if you wish to use ``Future`` you can translate Observables to Java native Futures:
+RX API has advantages over Future based APIs. But if you wish to use `Future` you can translate Observables to Java native Futures:
 
 ```java
 // You can convert an Observable to a ListenableFuture.
@@ -239,9 +245,11 @@ You can see more details on how to convert Observables to Futures here:
 https://dzone.com/articles/converting-between
 
 ## Checking out the Source Code
+
 The SDK is open source and is available here [sdk](sdk/).
 
- Clone the Repo
+Clone the Repo
+
 ```bash
 git clone https://github.com/Azure/azure-cosmosdb-java.git
 cd azure-cosmosdb-java
@@ -249,11 +257,23 @@ cd azure-cosmosdb-java
 
 ### How to Build from Command Line
 
-* Run the following maven command to build:
+- Run the following maven command to build:
 
 ```bash
 maven clean package -DskipTests
 ```
+
+### How to generate directory structure for publishing
+
+- Run the following maven command to collect the jars needed for publishing
+
+```bash
+mvn antrun:run -N
+```
+
+Note: the `-N` is required to assert this command is only run in the parent pom.
+
+Afterwards, you can upload the contents of `./target/collectedArtifactsForRelease` for publishing.
 
 #### Running Tests from Command Line
 
@@ -265,25 +285,27 @@ mvn test -DACCOUNT_HOST="https://REPLACE_ME_WITH_YOURS.documents.azure.com:443/"
 
 ### Import into Intellij or Eclipse
 
-* Load the main parent project pom file in Intellij/Eclipse (That should automatically load examples).
-* For running the samples you need a proper Azure Cosmos DB Endpoint. The endpoints are picked up from [TestConfigurations.java](examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/TestConfigurations.java). There is a similar endpoint config file for the sdk tests [here](sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TestConfigurations.java).
-* You can pass your endpoint credentials as VM Arguments in Eclipse JUnit Run Config:
+- Load the main parent project pom file in Intellij/Eclipse (That should automatically load examples).
+- For running the samples you need a proper Azure Cosmos DB Endpoint. The endpoints are picked up from [TestConfigurations.java](examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/TestConfigurations.java). There is a similar endpoint config file for the sdk tests [here](sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TestConfigurations.java).
+- You can pass your endpoint credentials as VM Arguments in Eclipse JUnit Run Config:
+
 ```bash
  -DACCOUNT_HOST="https://REPLACE_ME.documents.azure.com:443/" -DACCOUNT_KEY="REPLACE_ME"
- ```
-* or you can simply put your endpoint credentials in TestConfigurations.java
-* The SDK tests are written using TestNG framework, if you use Eclipse you may have to
+```
+
+- or you can simply put your endpoint credentials in TestConfigurations.java
+- The SDK tests are written using TestNG framework, if you use Eclipse you may have to
   add TestNG plugin to your eclipse IDE as explained [here](http://testng.org/doc/eclipse.html).
   Intellij has builtin support for TestNG.
-* Now you can run the tests in your Intellij/Eclipse IDE.
-
+- Now you can run the tests in your Intellij/Eclipse IDE.
 
 ## FAQ
+
 We have a frequently asked questions which is maintained [here](faq/).
 
 ## Release changes
-Release changelog is available [here](changelog/).
 
+Release changelog is available [here](changelog/).
 
 ## Contribution and Feedback
 
@@ -295,7 +317,7 @@ We have [travis build CI](https://travis-ci.org/Azure/azure-cosmosdb-java) which
 
 If you encounter any bugs with the SDK please file an [issue](https://github.com/Azure/azure-cosmosdb-java/issues) in the Issues section of the project.
 
-
 ## License
+
 MIT License
 Copyright (c) 2018 Copyright (c) Microsoft Corporation

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmos-parent</artifactId>
-    <version>3.0.0-a1</version>
+    <version>3.0.0-a1-SNAPSHOT</version>
   </parent>
   
   <artifactId>azure-cosmos-benchmark</artifactId>
@@ -94,6 +94,21 @@
               org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8
             </classpathContainer>
           </classpathContainers>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <phase>none</phase>
+            <id>default-cli</id>
+          </execution>
+        </executions>
+        <configuration>
+          <skip>true</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -28,11 +28,11 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.microsoft.azure</groupId>
-    <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <artifactId>azure-cosmos-parent</artifactId>
+    <version>3.0.0-a1</version>
   </parent>
   
-  <artifactId>azure-cosmosdb-benchmark</artifactId>
+  <artifactId>azure-cosmos-benchmark</artifactId>
   <name>Async SDK for SQL API of Azure Cosmos DB Service - Benchmarking tool</name>
   <description>Benchmarking tool for Async SDK for SQL API of Azure Cosmos DB Service</description>
 
@@ -101,11 +101,11 @@
   <dependencies>
     <dependency>
       <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-cosmosdb</artifactId>
+      <artifactId>azure-cosmos</artifactId>
     </dependency>
     <dependency>
       <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-cosmosdb-commons-test-utils</artifactId>
+      <artifactId>azure-cosmos-commons-test-utils</artifactId>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/commons-test-utils/pom.xml
+++ b/commons-test-utils/pom.xml
@@ -27,10 +27,10 @@ SOFTWARE.
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.microsoft.azure</groupId>
-    <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <artifactId>azure-cosmos-parent</artifactId>
+    <version>3.0.0-a1</version>
   </parent>
-  <artifactId>azure-cosmosdb-commons-test-utils</artifactId>
+  <artifactId>azure-cosmos-commons-test-utils</artifactId>
   <name>Common Test Components for Testing Async SDK for SQL API of Azure Cosmos DB Service</name>
   <description>Common Test Components for Testing Async SDK for SQL API of Azure Cosmos DB Service</description>
   <packaging>jar</packaging>
@@ -94,7 +94,7 @@ SOFTWARE.
   <dependencies>
     <dependency>
       <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-cosmosdb-commons</artifactId>
+      <artifactId>azure-cosmos-commons</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/commons-test-utils/pom.xml
+++ b/commons-test-utils/pom.xml
@@ -28,7 +28,7 @@ SOFTWARE.
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmos-parent</artifactId>
-    <version>3.0.0-a1</version>
+    <version>3.0.0-a1-SNAPSHOT</version>
   </parent>
   <artifactId>azure-cosmos-commons-test-utils</artifactId>
   <name>Common Test Components for Testing Async SDK for SQL API of Azure Cosmos DB Service</name>
@@ -69,6 +69,21 @@ SOFTWARE.
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <phase>none</phase>
+            <id>default-cli</id>
+          </execution>
+        </executions>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -26,10 +26,10 @@ SOFTWARE.
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.microsoft.azure</groupId>
-    <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <artifactId>azure-cosmos-parent</artifactId>
+    <version>3.0.0-a1</version>
   </parent>
-  <artifactId>azure-cosmosdb-commons</artifactId>
+  <artifactId>azure-cosmos-commons</artifactId>
   <name>Common Components for Async SDK for SQL API of Azure Cosmos DB Service</name>
   <description>Common Components for Async SDK for SQL API of Azure Cosmos DB Service</description>
   <packaging>jar</packaging>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmos-parent</artifactId>
-    <version>3.0.0-a1</version>
+    <version>3.0.0-a1-SNAPSHOT</version>
   </parent>
   <artifactId>azure-cosmos-commons</artifactId>
   <name>Common Components for Async SDK for SQL API of Azure Cosmos DB Service</name>
@@ -54,6 +54,21 @@ SOFTWARE.
               org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8
             </classpathContainer>
           </classpathContainers>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <phase>none</phase>
+            <id>default-cli</id>
+          </execution>
+        </executions>
+        <configuration>
+          <skip>true</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/internal/HttpConstants.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/internal/HttpConstants.java
@@ -272,7 +272,7 @@ public class HttpConstants {
         // TODO: FIXME we can use maven plugin for generating a version file
         // @see
         // https://stackoverflow.com/questions/2469922/generate-a-version-java-file-in-maven
-        public static final String SDK_VERSION = "3.0.0-a1";
+        public static final String SDK_VERSION = "3.0.0-a1-SNAPSHOT";
         public static final String SDK_NAME = "cosmosdb-java-sdk";
     }
 

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/internal/HttpConstants.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/internal/HttpConstants.java
@@ -24,7 +24,8 @@
 package com.microsoft.azure.cosmosdb.internal;
 
 /**
- * Used internally. HTTP constants in the Azure Cosmos DB database service Java SDK.
+ * Used internally. HTTP constants in the Azure Cosmos DB database service Java
+ * SDK.
  */
 public class HttpConstants {
     public static class HttpMethods {
@@ -125,7 +126,7 @@ public class HttpConstants {
         public static final String TARGET_LSN = "x-ms-target-lsn";
         public static final String TARGET_GLOBAL_COMMITTED_LSN = "x-ms-target-global-committed-lsn";
 
-        //Request validation
+        // Request validation
         public static final String REQUEST_VALIDATION_FAILURE = "x-ms-request-validation-failure";
 
         public static final String WRITE_REQUEST_TRIGGER_ADDRESS_REFRESH = "x-ms-write-request-trigger-refresh";
@@ -192,7 +193,7 @@ public class HttpConstants {
         public static final String INDEX_TRANSFORMATION_PROGRESS = "x-ms-documentdb-collection-index-transformation-progress";
         public static final String LAZY_INDEXING_PROGRESS = "x-ms-documentdb-collection-lazy-indexing-progress";
 
-        //Owner name
+        // Owner name
         public static final String OWNER_FULL_NAME = "x-ms-alt-content-path";
 
         // Owner ID used for name based request in session token.
@@ -218,7 +219,8 @@ public class HttpConstants {
         public static final String A_IM = "A-IM";
         public static final String ALLOW_TENTATIVE_WRITES = "x-ms-cosmos-allow-tentative-writes";
 
-        // These settings were added to support RNTBD and they've been added here to reduce merge conflicts
+        // These settings were added to support RNTBD and they've been added here to
+        // reduce merge conflicts
 
         public static final String CAN_CHARGE = "x-ms-cancharge";
         public static final String CAN_OFFER_REPLACE_COMPLETE = "x-ms-can-offer-replace-complete";
@@ -268,8 +270,9 @@ public class HttpConstants {
         public static final String CURRENT_VERSION = "2018-12-31";
 
         // TODO: FIXME we can use maven plugin for generating a version file
-        // @see https://stackoverflow.com/questions/2469922/generate-a-version-java-file-in-maven
-        public static final String SDK_VERSION = "3.0.0-SNAPSHOT";
+        // @see
+        // https://stackoverflow.com/questions/2469922/generate-a-version-java-file-in-maven
+        public static final String SDK_VERSION = "3.0.0-a1";
         public static final String SDK_NAME = "cosmosdb-java-sdk";
     }
 
@@ -296,7 +299,7 @@ public class HttpConstants {
     }
 
     public static class SubStatusCodes {
-        //  Unknown SubStatus Code
+        // Unknown SubStatus Code
         public static final int UNKNOWN = 0;
 
         // 400: Bad Request substatus
@@ -318,6 +321,6 @@ public class HttpConstants {
     }
 
     public static class HeaderValues {
-        public  static final String NoCache = "no-cache";
+        public static final String NoCache = "no-cache";
     }
 }

--- a/direct-impl/pom.xml
+++ b/direct-impl/pom.xml
@@ -27,14 +27,14 @@ SOFTWARE.
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-cosmos-direct</artifactId>
   <name>Azure Cosmos DB Async SDK Direct Internal Implementation</name>
-  <version>3.0.0-a1</version>
+  <version>3.0.0-a1-SNAPSHOT</version>
   <description>Azure Cosmos DB Async SDK Direct Internal Implementation</description>
   <url>https://docs.microsoft.com/en-us/azure/cosmos-db</url>
   <packaging>jar</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <test.groups>unit</test.groups>
-    <cosmosdb-sdk.version>3.0.0-a1</cosmosdb-sdk.version>
+    <cosmosdb-sdk.version>3.0.0-a1-SNAPSHOT</cosmosdb-sdk.version>
     <guava.version>27.0.1-jre</guava.version>
     </properties>
   <profiles>
@@ -219,7 +219,6 @@ SOFTWARE.
           </classpathContainers>
         </configuration>
       </plugin>
-
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.0.1</version>
@@ -260,6 +259,21 @@ SOFTWARE.
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <phase>none</phase>
+            <id>default-cli</id>
+          </execution>
+        </executions>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/direct-impl/pom.xml
+++ b/direct-impl/pom.xml
@@ -25,16 +25,16 @@ SOFTWARE.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.azure</groupId>
-  <artifactId>azure-cosmosdb-direct</artifactId>
+  <artifactId>azure-cosmos-direct</artifactId>
   <name>Azure Cosmos DB Async SDK Direct Internal Implementation</name>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0-a1</version>
   <description>Azure Cosmos DB Async SDK Direct Internal Implementation</description>
   <url>https://docs.microsoft.com/en-us/azure/cosmos-db</url>
   <packaging>jar</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <test.groups>unit</test.groups>
-    <cosmosdb-sdk.version>3.0.0-SNAPSHOT</cosmosdb-sdk.version>
+    <cosmosdb-sdk.version>3.0.0-a1</cosmosdb-sdk.version>
     <guava.version>27.0.1-jre</guava.version>
     </properties>
   <profiles>
@@ -285,12 +285,12 @@ SOFTWARE.
   <dependencies>
     <dependency>
       <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-cosmosdb-gateway</artifactId>
+      <artifactId>azure-cosmos-gateway</artifactId>
       <version>${cosmosdb-sdk.version}</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-cosmosdb-commons-test-utils</artifactId>
+      <artifactId>azure-cosmos-commons-test-utils</artifactId>
       <version>${cosmosdb-sdk.version}</version>
       <scope>test</scope>
     </dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmos-parent</artifactId>
-    <version>3.0.0-a1</version>
+    <version>3.0.0-a1-SNAPSHOT</version>
   </parent>
 
   <artifactId>azure-cosmos-examples</artifactId>
@@ -95,22 +95,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <phase>none</phase>
+            <id>default-cli</id>
+          </execution>
+        </executions>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <dependencies>
     <dependency>
-            <groupId>com.microsoft.azure</groupId>
-            <artifactId>azure-cosmos</artifactId>
-            </dependency>
+      <groupId>com.microsoft.azure</groupId>
+      <artifactId>azure-cosmos</artifactId>
+      </dependency>
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-cosmos-commons-test-utils</artifactId>
     </dependency>
-      <dependency>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-          <version>${guava.version}</version>
-      </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
     <dependency>
       <groupId>io.reactivex</groupId>
       <artifactId>rxjava-guava</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -28,11 +28,11 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.microsoft.azure</groupId>
-    <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <artifactId>azure-cosmos-parent</artifactId>
+    <version>3.0.0-a1</version>
   </parent>
 
-  <artifactId>azure-cosmosdb-examples</artifactId>
+  <artifactId>azure-cosmos-examples</artifactId>
   <name>Async SDK for SQL API of Azure Cosmos DB Service - Examples</name>
   <description>Examples for Async SDK for SQL API of Azure Cosmos DB Service</description>
 
@@ -100,11 +100,11 @@
   <dependencies>
     <dependency>
             <groupId>com.microsoft.azure</groupId>
-            <artifactId>azure-cosmosdb</artifactId>
+            <artifactId>azure-cosmos</artifactId>
             </dependency>
     <dependency>
       <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-cosmosdb-commons-test-utils</artifactId>
+      <artifactId>azure-cosmos-commons-test-utils</artifactId>
     </dependency>
       <dependency>
           <groupId>com.google.guava</groupId>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -26,10 +26,10 @@ SOFTWARE.
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.microsoft.azure</groupId>
-    <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <artifactId>azure-cosmos-parent</artifactId>
+    <version>3.0.0-a1</version>
   </parent>
-  <artifactId>azure-cosmosdb-gateway</artifactId>
+  <artifactId>azure-cosmos-gateway</artifactId>
   <name>Common Gateway Components for Async SDK for SQL API of Azure Cosmos DB Service</name>
   <description>Common Gateway Components for Async SDK for SQL API of Azure Cosmos DB Service</description>
   <packaging>jar</packaging>
@@ -80,11 +80,11 @@ SOFTWARE.
   <dependencies>
     <dependency>
       <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-cosmosdb-commons</artifactId>
+      <artifactId>azure-cosmos-commons</artifactId>
     </dependency>
     <dependency>
       <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-cosmosdb-commons-test-utils</artifactId>
+      <artifactId>azure-cosmos-commons-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmos-parent</artifactId>
-    <version>3.0.0-a1</version>
+    <version>3.0.0-a1-SNAPSHOT</version>
   </parent>
   <artifactId>azure-cosmos-gateway</artifactId>
   <name>Common Gateway Components for Async SDK for SQL API of Azure Cosmos DB Service</name>
@@ -54,6 +54,21 @@ SOFTWARE.
               org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8
             </classpathContainer>
           </classpathContainers>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <phase>none</phase>
+            <id>default-cli</id>
+          </execution>
+        </executions>
+        <configuration>
+          <skip>true</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-cosmos-parent</artifactId>
-  <version>3.0.0-a1</version>
+  <version>3.0.0-a1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Azure Cosmos DB SQL API</name>
   <description>Java Async SDK (with Reactive Extension RX support) for Azure Cosmos DB SQL API</description>
@@ -66,7 +66,10 @@
     <commons-validator-version>1.6</commons-validator-version>
     <reactor-bom.version>Bismuth-RELEASE</reactor-bom.version>
     <test.groups>unit</test.groups>
-    <cosmosdb-sdk-direct-impl.version>3.0.0-a1</cosmosdb-sdk-direct-impl.version>
+    <sdk-version>3.0.0-a1-SNAPSHOT</sdk-version>
+    <direct-connectivity-version>3.0.0-a1-SNAPSHOT</direct-connectivity-version>
+    <cosmosdb-sdk-direct-impl.version>3.0.0-a1-SNAPSHOT</cosmosdb-sdk-direct-impl.version>
+    <collectedArtifactsForReleaseLocation>${project.basedir}/target/collectedArtifactsForRelease</collectedArtifactsForReleaseLocation>
     <javadoc.opts/>
   </properties>
   <profiles>
@@ -301,6 +304,84 @@
             <id>attach-sources</id>
             <goals>
               <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.0</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-eclipse-plugin</artifactId>
+        <version>2.8</version>
+        <configuration>
+          <classpathContainers>
+            <classpathContainer>
+              org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8
+            </classpathContainer>
+          </classpathContainers>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <executions>
+          <execution>
+            <phase></phase>
+            <id>default-cli</id>
+            <configuration>
+              <target>
+                <copy file="sdk/pom.xml"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-${sdk-version}.pom"/>
+                <copy file="pom.xml"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-parent-${sdk-version}.pom"/>
+
+                 <copy file="sdk/target/azure-cosmos-${sdk-version}-sources.jar"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-${sdk-version}-sources.jar"/>
+                <copy file="sdk/target/azure-cosmos-${sdk-version}-javadoc.jar"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-${sdk-version}-javadoc.jar"/>
+                <copy file="sdk/target/azure-cosmos-${sdk-version}.jar"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-${sdk-version}.jar"/>
+
+                <copy file="commons/pom.xml"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-commons-${sdk-version}.pom"/>
+                <copy file="commons/target/azure-cosmos-commons-${sdk-version}-sources.jar"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-commons-${sdk-version}-sources.jar"/>
+                <copy file="commons/target/azure-cosmos-commons-${sdk-version}-javadoc.jar"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-commons-${sdk-version}-javadoc.jar"/>
+                <copy file="commons/target/azure-cosmos-commons-${sdk-version}.jar"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-commons-${sdk-version}.jar"/>
+
+                 <copy file="gateway/pom.xml"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-gateway-${sdk-version}.pom"/>
+                <copy file="gateway/target/azure-cosmos-gateway-${sdk-version}-sources.jar"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-gateway-${sdk-version}-sources.jar"/>
+                <copy file="gateway/target/azure-cosmos-gateway-${sdk-version}-javadoc.jar"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-gateway-${sdk-version}-javadoc.jar"/>
+                <copy file="gateway/target/azure-cosmos-gateway-${sdk-version}.jar"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-gateway-${sdk-version}.jar"/>
+
+                 <copy file="direct-impl/pom.xml"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-direct-${direct-connectivity-version}.pom"/>
+                <copy file="direct-impl/target/azure-cosmos-direct-${direct-connectivity-version}.jar"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-direct-${direct-connectivity-version}.jar"/>
+
+                <copy file="direct-impl/target/azure-cosmos-direct-${direct-connectivity-version}-empty-sources.jar"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-direct-${direct-connectivity-version}-sources.jar"/>
+                <copy file="direct-impl/target/azure-cosmos-direct-${direct-connectivity-version}-empty-javadoc.jar"
+                      tofile="${collectedArtifactsForReleaseLocation}/azure-cosmos-direct-${direct-connectivity-version}-javadoc.jar"/>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
             </goals>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.azure</groupId>
-  <artifactId>azure-cosmosdb-parent</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <artifactId>azure-cosmos-parent</artifactId>
+  <version>3.0.0-a1</version>
   <packaging>pom</packaging>
   <name>Azure Cosmos DB SQL API</name>
   <description>Java Async SDK (with Reactive Extension RX support) for Azure Cosmos DB SQL API</description>
@@ -66,7 +66,7 @@
     <commons-validator-version>1.6</commons-validator-version>
     <reactor-bom.version>Bismuth-RELEASE</reactor-bom.version>
     <test.groups>unit</test.groups>
-    <cosmosdb-sdk-direct-impl.version>3.0.0-SNAPSHOT</cosmosdb-sdk-direct-impl.version>
+    <cosmosdb-sdk-direct-impl.version>3.0.0-a1</cosmosdb-sdk-direct-impl.version>
     <javadoc.opts/>
   </properties>
   <profiles>
@@ -330,27 +330,27 @@
     <dependencies>
       <dependency>
         <groupId>com.microsoft.azure</groupId>
-        <artifactId>azure-cosmosdb</artifactId>
+        <artifactId>azure-cosmos</artifactId>
         <version>${project.parent.version}</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.azure</groupId>
-        <artifactId>azure-cosmosdb-commons</artifactId>
+        <artifactId>azure-cosmos-commons</artifactId>
         <version>${project.parent.version}</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.azure</groupId>
-        <artifactId>azure-cosmosdb-gateway</artifactId>
+        <artifactId>azure-cosmos-gateway</artifactId>
         <version>${project.parent.version}</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.azure</groupId>
-        <artifactId>azure-cosmosdb-direct</artifactId>
+        <artifactId>azure-cosmos-direct</artifactId>
         <version>${cosmosdb-sdk-direct-impl.version}</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.azure</groupId>
-        <artifactId>azure-cosmosdb-commons-test-utils</artifactId>
+        <artifactId>azure-cosmos-commons-test-utils</artifactId>
         <version>${project.parent.version}</version>
       </dependency>
       <dependency>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmos-parent</artifactId>
-    <version>3.0.0-a1</version>
+    <version>3.0.0-a1-SNAPSHOT</version>
   </parent>
   <artifactId>azure-cosmos</artifactId>
   <name>Async SDK for SQL API of Azure Cosmos DB Service</name>
@@ -68,6 +68,21 @@ SOFTWARE.
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <phase>none</phase>
+            <id>default-cli</id>
+          </execution>
+        </executions>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -26,10 +26,10 @@ SOFTWARE.
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.microsoft.azure</groupId>
-    <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <artifactId>azure-cosmos-parent</artifactId>
+    <version>3.0.0-a1</version>
   </parent>
-  <artifactId>azure-cosmosdb</artifactId>
+  <artifactId>azure-cosmos</artifactId>
   <name>Async SDK for SQL API of Azure Cosmos DB Service</name>
   <description>Java Async SDK (with Reactive Extension rx support) for Azure Cosmos DB SQL API</description>
   <packaging>jar</packaging>
@@ -146,19 +146,19 @@ SOFTWARE.
   <dependencies>
     <dependency>
       <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-cosmosdb-commons</artifactId>
+      <artifactId>azure-cosmos-commons</artifactId>
     </dependency>
     <dependency>
       <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-cosmosdb-gateway</artifactId>
+      <artifactId>azure-cosmos-gateway</artifactId>
     </dependency>
     <dependency>
       <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-cosmosdb-direct</artifactId>
+      <artifactId>azure-cosmos-direct</artifactId>
     </dependency>
     <dependency>
       <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-cosmosdb-commons-test-utils</artifactId>
+      <artifactId>azure-cosmos-commons-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This PR:
- closes #168 - renames the packages to azure-cosmos-* (from azure-cosmosdb-*)
- bumps the version to 3.0.0-a1 (which I released adhoc) and then 3.0.0-a1-SNAPSHOT
- adds antrun:run@default-cli goal to collect the packages into an easy format for publishing (and updates README)

Recommend disabling seeing whitespace changes in the PR for the Readme. My markdown prettifier cleaned up some whitespace stuff.