### PR TITLE
Hide Json Serializable

### DIFF
--- a/benchmark/src/main/java/com/azure/data/cosmos/benchmark/AsyncBenchmark.java
+++ b/benchmark/src/main/java/com/azure/data/cosmos/benchmark/AsyncBenchmark.java
@@ -24,6 +24,7 @@
 package com.azure.data.cosmos.benchmark;
 
 import com.azure.data.cosmos.AsyncDocumentClient;
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.Database;
 import com.azure.data.cosmos.Document;
 import com.azure.data.cosmos.DocumentCollection;
@@ -100,12 +101,12 @@ abstract class AsyncBenchmark<T> {
                 String uuid = UUID.randomUUID().toString();
                 Document newDoc = new Document();
                 newDoc.id(uuid);
-                newDoc.set(partitionKey, uuid);
-                newDoc.set("dataField1", dataFieldValue);
-                newDoc.set("dataField2", dataFieldValue);
-                newDoc.set("dataField3", dataFieldValue);
-                newDoc.set("dataField4", dataFieldValue);
-                newDoc.set("dataField5", dataFieldValue);
+                BridgeInternal.setProperty(newDoc, partitionKey, uuid);
+                BridgeInternal.setProperty(newDoc, "dataField1", dataFieldValue);
+                BridgeInternal.setProperty(newDoc, "dataField2", dataFieldValue);
+                BridgeInternal.setProperty(newDoc, "dataField3", dataFieldValue);
+                BridgeInternal.setProperty(newDoc, "dataField4", dataFieldValue);
+                BridgeInternal.setProperty(newDoc, "dataField5", dataFieldValue);
                 Flux<Document> obs = client.createDocument(collection.selfLink(), newDoc, null, false)
                                                  .map(ResourceResponse::getResource);
                 createDocumentObservables.add(obs);

--- a/benchmark/src/main/java/com/azure/data/cosmos/benchmark/AsyncMixedBenchmark.java
+++ b/benchmark/src/main/java/com/azure/data/cosmos/benchmark/AsyncMixedBenchmark.java
@@ -23,6 +23,7 @@
 
 package com.azure.data.cosmos.benchmark;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.Document;
 import com.azure.data.cosmos.FeedOptions;
 import com.azure.data.cosmos.PartitionKey;
@@ -57,12 +58,12 @@ class AsyncMixedBenchmark extends AsyncBenchmark<Document> {
             String idString = uuid + i;
             Document newDoc = new Document();
             newDoc.id(idString);
-            newDoc.set(partitionKey, idString);
-            newDoc.set("dataField1", dataFieldValue);
-            newDoc.set("dataField2", dataFieldValue);
-            newDoc.set("dataField3", dataFieldValue);
-            newDoc.set("dataField4", dataFieldValue);
-            newDoc.set("dataField5", dataFieldValue);
+            BridgeInternal.setProperty(newDoc, partitionKey, idString);
+            BridgeInternal.setProperty(newDoc, "dataField1", dataFieldValue);
+            BridgeInternal.setProperty(newDoc, "dataField2", dataFieldValue);
+            BridgeInternal.setProperty(newDoc, "dataField3", dataFieldValue);
+            BridgeInternal.setProperty(newDoc, "dataField4", dataFieldValue);
+            BridgeInternal.setProperty(newDoc, "dataField5", dataFieldValue);
             obs = client.createDocument(getCollectionLink(), newDoc, null, false).map(ResourceResponse::getResource);
 
         } else if (i % 100 == 0) {

--- a/benchmark/src/main/java/com/azure/data/cosmos/benchmark/AsyncWriteBenchmark.java
+++ b/benchmark/src/main/java/com/azure/data/cosmos/benchmark/AsyncWriteBenchmark.java
@@ -23,6 +23,7 @@
 
 package com.azure.data.cosmos.benchmark;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.Document;
 import com.azure.data.cosmos.ResourceResponse;
 import com.codahale.metrics.Timer;
@@ -82,12 +83,12 @@ class AsyncWriteBenchmark extends AsyncBenchmark<ResourceResponse<Document>> {
         String idString = uuid + i;
         Document newDoc = new Document();
         newDoc.id(idString);
-        newDoc.set(partitionKey, idString);
-        newDoc.set("dataField1", dataFieldValue);
-        newDoc.set("dataField2", dataFieldValue);
-        newDoc.set("dataField3", dataFieldValue);
-        newDoc.set("dataField4", dataFieldValue);
-        newDoc.set("dataField5", dataFieldValue);
+        BridgeInternal.setProperty(newDoc, partitionKey, idString);
+        BridgeInternal.setProperty(newDoc, "dataField1", dataFieldValue);
+        BridgeInternal.setProperty(newDoc, "dataField2", dataFieldValue);
+        BridgeInternal.setProperty(newDoc, "dataField3", dataFieldValue);
+        BridgeInternal.setProperty(newDoc, "dataField4", dataFieldValue);
+        BridgeInternal.setProperty(newDoc, "dataField5", dataFieldValue);
         Flux<ResourceResponse<Document>> obs = client.createDocument(getCollectionLink(), newDoc, null,
                 false);
 

--- a/benchmark/src/main/java/com/azure/data/cosmos/benchmark/ReadMyWriteWorkflow.java
+++ b/benchmark/src/main/java/com/azure/data/cosmos/benchmark/ReadMyWriteWorkflow.java
@@ -23,6 +23,7 @@
 
 package com.azure.data.cosmos.benchmark;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.Document;
 import com.azure.data.cosmos.FeedOptions;
 import com.azure.data.cosmos.PartitionKey;
@@ -178,12 +179,12 @@ class ReadMyWriteWorkflow extends AsyncBenchmark<Document> {
         String randomVal = Utils.randomUUID().toString();
         Document document = new Document();
         document.id(idString);
-        document.set(partitionKey, idString);
-        document.set(QUERY_FIELD_NAME, randomVal);
-        document.set("dataField1", randomVal);
-        document.set("dataField2", randomVal);
-        document.set("dataField3", randomVal);
-        document.set("dataField4", randomVal);
+        BridgeInternal.setProperty(document, partitionKey, idString);
+        BridgeInternal.setProperty(document, QUERY_FIELD_NAME, randomVal);
+        BridgeInternal.setProperty(document, "dataField1", randomVal);
+        BridgeInternal.setProperty(document, "dataField2", randomVal);
+        BridgeInternal.setProperty(document, "dataField3", randomVal);
+        BridgeInternal.setProperty(document, "dataField4", randomVal);
 
         Integer key = i == null ? cacheKey() : i;
         return client.createDocument(getCollectionLink(), document, null, false)

--- a/benchmark/src/test/java/com/azure/data/cosmos/benchmark/ReadMyWritesConsistencyTest.java
+++ b/benchmark/src/test/java/com/azure/data/cosmos/benchmark/ReadMyWritesConsistencyTest.java
@@ -24,6 +24,7 @@
 package com.azure.data.cosmos.benchmark;
 
 import com.azure.data.cosmos.AsyncDocumentClient;
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.DataType;
 import com.azure.data.cosmos.Database;
 import com.azure.data.cosmos.DocumentCollection;
@@ -176,11 +177,11 @@ public class ReadMyWritesConsistencyTest {
         includedPath.path("/*");
         Collection<Index> indexes = new ArrayList<>();
         Index stringIndex = Index.Range(DataType.STRING);
-        stringIndex.set("precision", -1);
+        BridgeInternal.setProperty(stringIndex, "precision", -1);
         indexes.add(stringIndex);
 
         Index numberIndex = Index.Range(DataType.NUMBER);
-        numberIndex.set("precision", -1);
+        BridgeInternal.setProperty(numberIndex, "precision", -1);
         indexes.add(numberIndex);
         includedPath.indexes(indexes);
         includedPaths.add(includedPath);

--- a/benchmark/src/test/java/com/azure/data/cosmos/benchmark/WorkflowTest.java
+++ b/benchmark/src/test/java/com/azure/data/cosmos/benchmark/WorkflowTest.java
@@ -24,6 +24,7 @@
 package com.azure.data.cosmos.benchmark;
 
 import com.azure.data.cosmos.AsyncDocumentClient;
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.DataType;
 import com.azure.data.cosmos.Database;
 import com.azure.data.cosmos.DocumentCollection;
@@ -328,11 +329,11 @@ public class WorkflowTest {
         includedPath.path("/*");
         Collection<Index> indexes = new ArrayList<>();
         Index stringIndex = Index.Range(DataType.STRING);
-        stringIndex.set("precision", -1);
+        BridgeInternal.setProperty(stringIndex, "precision", -1);
         indexes.add(stringIndex);
 
         Index numberIndex = Index.Range(DataType.NUMBER);
-        numberIndex.set("precision", -1);
+        BridgeInternal.setProperty(numberIndex, "precision", -1);
         indexes.add(numberIndex);
         includedPath.indexes(indexes);
         includedPaths.add(includedPath);

--- a/commons/src/main/java/com/azure/data/cosmos/BridgeInternal.java
+++ b/commons/src/main/java/com/azure/data/cosmos/BridgeInternal.java
@@ -295,4 +295,12 @@ public class BridgeInternal {
     public static PartitionKey getPartitionKey(PartitionKeyInternal partitionKeyInternal) {
         return new PartitionKey(partitionKeyInternal);
     }
+
+    public static <T> void setProperty(JsonSerializable jsonSerializable, String propertyName, T value) {
+        jsonSerializable.set(propertyName, value);
+    }
+
+    public static void remove(JsonSerializable jsonSerializable, String propertyName) {
+        jsonSerializable.remove(propertyName);
+    }
 }

--- a/commons/src/main/java/com/azure/data/cosmos/JsonSerializable.java
+++ b/commons/src/main/java/com/azure/data/cosmos/JsonSerializable.java
@@ -86,7 +86,7 @@ public class JsonSerializable {
         this.propertyBag = objectNode;
     }
 
-    ObjectMapper getMapper() {
+    private ObjectMapper getMapper() {
         // TODO: Made package private due to #153. #171 adding custom serialization options back.
         if (this.om != null) { return this.om; }
         return OBJECT_MAPPER;
@@ -103,7 +103,7 @@ public class JsonSerializable {
         }
     }
 
-    protected Logger getLogger() {
+    Logger getLogger() {
         return logger;
     }
 
@@ -134,7 +134,7 @@ public class JsonSerializable {
      * 
      * @param propertyName the property to remove.
      */
-    public void remove(String propertyName) {
+    void remove(String propertyName) {
         this.propertyBag.remove(propertyName);
     }
 
@@ -146,7 +146,7 @@ public class JsonSerializable {
      * @param value        the value of the property.
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public <T> void set(String propertyName, T value) {
+    <T> void set(String propertyName, T value) {
         if (value == null) {
             // Sets null.
             this.propertyBag.putNull(propertyName);
@@ -416,7 +416,7 @@ public class JsonSerializable {
      * @param propertyName the property to get.
      * @return the JSONObject.
      */
-    public ObjectNode getObject(String propertyName) {
+    ObjectNode getObject(String propertyName) {
         if (this.propertyBag.has(propertyName) && this.propertyBag.hasNonNull(propertyName)) {
             ObjectNode jsonObj = (ObjectNode) this.propertyBag.get(propertyName);
             return jsonObj;
@@ -430,7 +430,7 @@ public class JsonSerializable {
      * @param propertyName the property to get.
      * @return the JSONObject collection.
      */
-    public Collection<ObjectNode> getCollection(String propertyName) {
+    Collection<ObjectNode> getCollection(String propertyName) {
         Collection<ObjectNode> result = null;
         if (this.propertyBag.has(propertyName) && this.propertyBag.hasNonNull(propertyName)) {
             result = new ArrayList<ObjectNode>();

--- a/commons/src/main/java/com/azure/data/cosmos/directconnectivity/Address.java
+++ b/commons/src/main/java/com/azure/data/cosmos/directconnectivity/Address.java
@@ -23,6 +23,7 @@
 
 package com.azure.data.cosmos.directconnectivity;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.Resource;
 import com.azure.data.cosmos.internal.Constants;
 
@@ -51,7 +52,7 @@ public class Address extends Resource {
     }
 
     void setIsPrimary(boolean isPrimary) {
-        super.set(Constants.Properties.IS_PRIMARY, isPrimary);
+        BridgeInternal.setProperty(this, Constants.Properties.IS_PRIMARY, isPrimary);
     }
 
     public String getProtocolScheme() {
@@ -59,7 +60,7 @@ public class Address extends Resource {
     }
 
     void setProtocol(String protocol) {
-        super.set(Constants.Properties.PROTOCOL, protocol);
+        BridgeInternal.setProperty(this, Constants.Properties.PROTOCOL, protocol);
     }
 
     public String getLogicalUri() {
@@ -67,7 +68,7 @@ public class Address extends Resource {
     }
 
     void setLogicalUri(String logicalUri) {
-        super.set(Constants.Properties.LOGICAL_URI, logicalUri);
+        BridgeInternal.setProperty(this, Constants.Properties.LOGICAL_URI, logicalUri);
     }
 
     public String getPhyicalUri() {
@@ -75,7 +76,7 @@ public class Address extends Resource {
     }
 
     void setPhysicalUri(String phyicalUri) {
-        super.set(Constants.Properties.PHYISCAL_URI, phyicalUri);
+        BridgeInternal.setProperty(this, Constants.Properties.PHYISCAL_URI, phyicalUri);
     }
 
     public String getPartitionIndex() {
@@ -83,7 +84,7 @@ public class Address extends Resource {
     }
 
     void setPartitionIndex(String partitionIndex) {
-        super.set(Constants.Properties.PARTITION_INDEX, partitionIndex);
+        BridgeInternal.setProperty(this, Constants.Properties.PARTITION_INDEX, partitionIndex);
     }
 
     public String getParitionKeyRangeId() {
@@ -91,6 +92,6 @@ public class Address extends Resource {
     }
 
     public void setPartitionKeyRangeId(String partitionKeyRangeId) {
-        super.set(Constants.Properties.PARTITION_KEY_RANGE_ID, partitionKeyRangeId);
+        BridgeInternal.setProperty(this, Constants.Properties.PARTITION_KEY_RANGE_ID, partitionKeyRangeId);
     }
 }

--- a/commons/src/main/java/com/azure/data/cosmos/internal/routing/Range.java
+++ b/commons/src/main/java/com/azure/data/cosmos/internal/routing/Range.java
@@ -23,6 +23,7 @@
 
 package com.azure.data.cosmos.internal.routing;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.JsonSerializable;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -89,7 +90,7 @@ public final class Range<T extends Comparable<T>> extends JsonSerializable {
 
     public void setMin(T min) {
         this.minValue = min;
-        super.set(Range.MIN_PROPERTY, min);
+        BridgeInternal.setProperty(this, Range.MIN_PROPERTY, min);
     }
 
     @SuppressWarnings("unchecked")
@@ -103,7 +104,7 @@ public final class Range<T extends Comparable<T>> extends JsonSerializable {
 
     public void setMax(T max) {
         this.maxValue = max;
-        super.set(Range.MAX_PROPERTY, max);
+        BridgeInternal.setProperty(this, Range.MAX_PROPERTY, max);
     }
 
     @JsonProperty("isMinInclusive")
@@ -112,7 +113,7 @@ public final class Range<T extends Comparable<T>> extends JsonSerializable {
     }
 
     public void setMinInclusive(boolean isMinInclusive) {
-        super.set(Range.IS_MIN_INCLUSIVE_PROPERTY, isMinInclusive);
+        BridgeInternal.setProperty(this, Range.IS_MIN_INCLUSIVE_PROPERTY, isMinInclusive);
     }
 
     @JsonProperty("isMaxInclusive")
@@ -121,7 +122,7 @@ public final class Range<T extends Comparable<T>> extends JsonSerializable {
     }
 
     public void setMaxInclusive(boolean isMaxInclusive) {
-        super.set(Range.IS_MAX_INCLUSIVE_PROPERTY, isMaxInclusive);
+        BridgeInternal.setProperty(this, Range.IS_MAX_INCLUSIVE_PROPERTY, isMaxInclusive);
     }
 
     public boolean isSingleValue() {

--- a/examples/src/main/java/com/azure/data/cosmos/rx/examples/multimaster/samples/ConflictWorker.java
+++ b/examples/src/main/java/com/azure/data/cosmos/rx/examples/multimaster/samples/ConflictWorker.java
@@ -26,6 +26,7 @@ package com.azure.data.cosmos.rx.examples.multimaster.samples;
 import com.azure.data.cosmos.AccessCondition;
 import com.azure.data.cosmos.AccessConditionType;
 import com.azure.data.cosmos.AsyncDocumentClient;
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.Conflict;
 import com.azure.data.cosmos.ConflictResolutionPolicy;
 import com.azure.data.cosmos.CosmosClientException;
@@ -498,8 +499,8 @@ public class ConflictWorker {
     private Flux<Document> tryInsertDocument(AsyncDocumentClient client, String collectionUri, Document document, int index) {
 
         logger.debug("region: {}", client.getWriteEndpoint());
-        document.set("regionId", index);
-        document.set("regionEndpoint", client.getReadEndpoint());
+        BridgeInternal.setProperty(document, "regionId", index);
+        BridgeInternal.setProperty(document, "regionEndpoint", client.getReadEndpoint());
         return client.createDocument(collectionUri, document, null, false)
                 .onErrorResume(e -> {
                     if (hasDocumentClientException(e, 409)) {
@@ -544,8 +545,8 @@ public class ConflictWorker {
     }
 
     private Flux<Document> tryUpdateDocument(AsyncDocumentClient client, String collectionUri, Document document, int index) {
-        document.set("regionId", index);
-        document.set("regionEndpoint", client.getReadEndpoint());
+        BridgeInternal.setProperty(document, "regionId", index);
+        BridgeInternal.setProperty(document, "regionEndpoint", client.getReadEndpoint());
 
         RequestOptions options = new RequestOptions();
         options.setAccessCondition(new AccessCondition());
@@ -566,8 +567,8 @@ public class ConflictWorker {
     }
 
     private Flux<Document> tryDeleteDocument(AsyncDocumentClient client, String collectionUri, Document document, int index) {
-        document.set("regionId", index);
-        document.set("regionEndpoint", client.getReadEndpoint());
+        BridgeInternal.setProperty(document, "regionId", index);
+        BridgeInternal.setProperty(document, "regionEndpoint", client.getReadEndpoint());
 
         RequestOptions options = new RequestOptions();
         options.setAccessCondition(new AccessCondition());

--- a/examples/src/test/java/com/azure/data/cosmos/rx/examples/CollectionCRUDAsyncAPITest.java
+++ b/examples/src/test/java/com/azure/data/cosmos/rx/examples/CollectionCRUDAsyncAPITest.java
@@ -23,6 +23,7 @@
 package com.azure.data.cosmos.rx.examples;
 
 import com.azure.data.cosmos.AsyncDocumentClient;
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.ConnectionMode;
 import com.azure.data.cosmos.ConnectionPolicy;
 import com.azure.data.cosmos.ConsistencyLevel;
@@ -398,11 +399,11 @@ public class CollectionCRUDAsyncAPITest extends DocumentClientTest {
         includedPath.path("/*");
         Collection<Index> indexes = new ArrayList<>();
         Index stringIndex = Index.Range(DataType.STRING);
-        stringIndex.set("precision", -1);
+        BridgeInternal.setProperty(stringIndex, "precision", -1);
         indexes.add(stringIndex);
 
         Index numberIndex = Index.Range(DataType.NUMBER);
-        numberIndex.set("precision", -1);
+        BridgeInternal.setProperty(numberIndex, "precision", -1);
         indexes.add(numberIndex);
         includedPath.indexes(indexes);
         includedPaths.add(includedPath);

--- a/examples/src/test/java/com/azure/data/cosmos/rx/examples/DocumentCRUDAsyncAPITest.java
+++ b/examples/src/test/java/com/azure/data/cosmos/rx/examples/DocumentCRUDAsyncAPITest.java
@@ -23,6 +23,7 @@
 package com.azure.data.cosmos.rx.examples;
 
 import com.azure.data.cosmos.AsyncDocumentClient;
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.ConnectionMode;
 import com.azure.data.cosmos.ConnectionPolicy;
 import com.azure.data.cosmos.ConsistencyLevel;
@@ -217,7 +218,7 @@ public class DocumentCRUDAsyncAPITest extends DocumentClientTest {
     public void createDocumentWithProgrammableDocumentDefinition() throws Exception {
         Document documentDefinition = new Document();
         documentDefinition.id("test-document");
-        documentDefinition.set("counter", 1);
+        BridgeInternal.setProperty(documentDefinition, "counter", 1);
 
         // CREATE a document
         Document createdDocument = client

--- a/examples/src/test/java/com/azure/data/cosmos/rx/examples/OfferCRUDAsyncAPITest.java
+++ b/examples/src/test/java/com/azure/data/cosmos/rx/examples/OfferCRUDAsyncAPITest.java
@@ -24,6 +24,7 @@
 package com.azure.data.cosmos.rx.examples;
 
 import com.azure.data.cosmos.AsyncDocumentClient;
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.ConnectionMode;
 import com.azure.data.cosmos.ConnectionPolicy;
 import com.azure.data.cosmos.ConsistencyLevel;
@@ -160,11 +161,11 @@ public class OfferCRUDAsyncAPITest extends DocumentClientTest {
         includedPath.path("/*");
         Collection<Index> indexes = new ArrayList<>();
         Index stringIndex = Index.Range(DataType.STRING);
-        stringIndex.set("precision", -1);
+        BridgeInternal.setProperty(stringIndex, "precision", -1);
         indexes.add(stringIndex);
 
         Index numberIndex = Index.Range(DataType.NUMBER);
-        numberIndex.set("precision", -1);
+        BridgeInternal.setProperty(numberIndex, "precision", -1);
         indexes.add(numberIndex);
         includedPath.indexes(indexes);
         includedPaths.add(includedPath);

--- a/examples/src/test/java/com/azure/data/cosmos/rx/examples/StoredProcedureAsyncAPITest.java
+++ b/examples/src/test/java/com/azure/data/cosmos/rx/examples/StoredProcedureAsyncAPITest.java
@@ -24,6 +24,7 @@
 package com.azure.data.cosmos.rx.examples;
 
 import com.azure.data.cosmos.AsyncDocumentClient;
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.ConnectionMode;
 import com.azure.data.cosmos.ConnectionPolicy;
 import com.azure.data.cosmos.ConsistencyLevel;
@@ -250,11 +251,11 @@ public class StoredProcedureAsyncAPITest extends DocumentClientTest {
         includedPath.path("/*");
         Collection<Index> indexes = new ArrayList<Index>();
         Index stringIndex = Index.Range(DataType.STRING);
-        stringIndex.set("precision", -1);
+        BridgeInternal.setProperty(stringIndex, "precision", -1);
         indexes.add(stringIndex);
 
         Index numberIndex = Index.Range(DataType.NUMBER);
-        numberIndex.set("precision", -1);
+        BridgeInternal.setProperty(numberIndex, "precision", -1);
         indexes.add(numberIndex);
         includedPath.indexes(indexes);
         includedPaths.add(includedPath);

--- a/gateway/src/main/java/com/azure/data/cosmos/internal/query/AggregateDocumentQueryExecutionContext.java
+++ b/gateway/src/main/java/com/azure/data/cosmos/internal/query/AggregateDocumentQueryExecutionContext.java
@@ -118,7 +118,7 @@ public class AggregateDocumentQueryExecutionContext<T extends Resource> implemen
                     
                     if (this.aggregator.getResult() == null || !this.aggregator.getResult().equals(Undefined.Value())) {
                         Document aggregateDocument = new Document();
-                        aggregateDocument.set(Constants.Properties.AGGREGATE, this.aggregator.getResult());
+                        BridgeInternal.setProperty(aggregateDocument, Constants.Properties.AGGREGATE, this.aggregator.getResult());
                         aggregateResults.add(aggregateDocument);
                     }
 

--- a/gateway/src/main/java/com/azure/data/cosmos/internal/query/CompositeContinuationToken.java
+++ b/gateway/src/main/java/com/azure/data/cosmos/internal/query/CompositeContinuationToken.java
@@ -23,6 +23,7 @@
 
 package com.azure.data.cosmos.internal.query;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.JsonSerializable;
 import com.azure.data.cosmos.internal.Utils.ValueHolder;
 import com.azure.data.cosmos.internal.routing.Range;
@@ -105,7 +106,7 @@ public final class CompositeContinuationToken extends JsonSerializable {
      *            the token to set
      */
     private void setToken(String token) {
-        super.set(TokenPropertyName, token);
+        BridgeInternal.setProperty(this, TokenPropertyName, token);
     }
 
     /**
@@ -114,6 +115,6 @@ public final class CompositeContinuationToken extends JsonSerializable {
      */
     private void setRange(Range<String> range) {
         /* TODO: Don't stringify the range */
-        super.set(RangePropertyName, range.toString());
+        BridgeInternal.setProperty(this, RangePropertyName, range.toString());
     }
 }

--- a/gateway/src/main/java/com/azure/data/cosmos/internal/query/OrderByContinuationToken.java
+++ b/gateway/src/main/java/com/azure/data/cosmos/internal/query/OrderByContinuationToken.java
@@ -23,6 +23,7 @@
 
 package com.azure.data.cosmos.internal.query;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.JsonSerializable;
 import com.azure.data.cosmos.internal.Utils.ValueHolder;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -135,18 +136,18 @@ public final class OrderByContinuationToken extends JsonSerializable {
     }
 
     private void setCompositeContinuationToken(CompositeContinuationToken compositeContinuationToken) {
-        super.set(CompositeContinuationTokenPropertyName, compositeContinuationToken.toJson());
+        BridgeInternal.setProperty(this, CompositeContinuationTokenPropertyName, compositeContinuationToken.toJson());
     }
 
     private void setOrderByItems(QueryItem[] orderByItems) {
-        super.set(OrderByItemsPropetryName, orderByItems);
+        BridgeInternal.setProperty(this, OrderByItemsPropetryName, orderByItems);
     }
 
     private void setRid(String rid) {
-        super.set(RidPropertyName, rid);
+        BridgeInternal.setProperty(this, RidPropertyName, rid);
     }
 
     private void setInclusive(boolean inclusive) {
-        super.set(InclusivePropertyName, inclusive);
+        BridgeInternal.setProperty(this, InclusivePropertyName, inclusive);
     }
 }

--- a/gateway/src/main/java/com/azure/data/cosmos/internal/query/PartitionedQueryExecutionInfo.java
+++ b/gateway/src/main/java/com/azure/data/cosmos/internal/query/PartitionedQueryExecutionInfo.java
@@ -23,6 +23,7 @@
 
 package com.azure.data.cosmos.internal.query;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.JsonSerializable;
 import com.azure.data.cosmos.internal.Constants;
 import com.azure.data.cosmos.internal.routing.Range;
@@ -44,7 +45,7 @@ public final class PartitionedQueryExecutionInfo extends JsonSerializable {
         this.queryInfo = queryInfo;
         this.queryRanges = queryRanges;
 
-        super.set(
+        BridgeInternal.setProperty(this, 
                 PartitionedQueryExecutionInfoInternal.PARTITIONED_QUERY_EXECUTION_INFO_VERSION_PROPERTY,
                 Constants.PartitionedQueryExecutionInfo.VERSION_1);
     }

--- a/gateway/src/main/java/com/azure/data/cosmos/internal/query/PartitionedQueryExecutionInfoInternal.java
+++ b/gateway/src/main/java/com/azure/data/cosmos/internal/query/PartitionedQueryExecutionInfoInternal.java
@@ -23,6 +23,7 @@
 
 package com.azure.data.cosmos.internal.query;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.JsonSerializable;
 import com.azure.data.cosmos.internal.Constants;
 import com.azure.data.cosmos.internal.Utils;
@@ -45,7 +46,7 @@ public final class PartitionedQueryExecutionInfoInternal extends JsonSerializabl
     private List<Range<PartitionKeyInternal>> queryRanges;
 
     public PartitionedQueryExecutionInfoInternal() {
-        super.set(PARTITIONED_QUERY_EXECUTION_INFO_VERSION_PROPERTY, Constants.PartitionedQueryExecutionInfo.VERSION_1);
+        BridgeInternal.setProperty(this, PARTITIONED_QUERY_EXECUTION_INFO_VERSION_PROPERTY, Constants.PartitionedQueryExecutionInfo.VERSION_1);
     }
 
     public PartitionedQueryExecutionInfoInternal(String jsonString) {

--- a/gateway/src/main/java/com/azure/data/cosmos/internal/query/TakeContinuationToken.java
+++ b/gateway/src/main/java/com/azure/data/cosmos/internal/query/TakeContinuationToken.java
@@ -23,6 +23,7 @@
 
 package com.azure.data.cosmos.internal.query;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.JsonSerializable;
 import com.azure.data.cosmos.internal.Utils.ValueHolder;
 import org.slf4j.Logger;
@@ -82,10 +83,10 @@ public final class TakeContinuationToken extends JsonSerializable {
     }
 
     private void setTakeCount(int takeCount) {
-        super.set(LimitPropertyName, takeCount);
+        BridgeInternal.setProperty(this, LimitPropertyName, takeCount);
     }
 
     private void setSourceToken(String sourceToken) {
-        super.set(SourceTokenPropetryName, sourceToken);
+        BridgeInternal.setProperty(this, SourceTokenPropetryName, sourceToken);
     }
 }

--- a/sdk/src/test/java/com/azure/data/cosmos/directconnectivity/DCDocumentCrudTest.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/directconnectivity/DCDocumentCrudTest.java
@@ -23,6 +23,7 @@
 package com.azure.data.cosmos.directconnectivity;
 
 import com.azure.data.cosmos.AsyncDocumentClient.Builder;
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.ConnectionMode;
 import com.azure.data.cosmos.ConnectionPolicy;
 import com.azure.data.cosmos.ConsistencyLevel;
@@ -208,7 +209,7 @@ public class DCDocumentCrudTest extends TestSuiteBase {
 
         String propName = "newProp";
         String propValue = "hello";
-        document.set(propName, propValue);
+        BridgeInternal.setProperty(document, propName, propValue);
         
         ResourceResponseValidator<Document> validator = ResourceResponseValidator.builder()
                 .withProperty(propName, propValue)
@@ -331,8 +332,8 @@ public class DCDocumentCrudTest extends TestSuiteBase {
     private Document getDocumentDefinition() {
         Document doc = new Document();
         doc.id(UUID.randomUUID().toString());
-        doc.set(PARTITION_KEY_FIELD_NAME, UUID.randomUUID().toString());
-        doc.set("name", "Hafez");
+        BridgeInternal.setProperty(doc, PARTITION_KEY_FIELD_NAME, UUID.randomUUID().toString());
+        BridgeInternal.setProperty(doc, "name", "Hafez");
         return doc;
     }
     

--- a/sdk/src/test/java/com/azure/data/cosmos/internal/ConsistencyTests2.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/internal/ConsistencyTests2.java
@@ -24,6 +24,7 @@
 package com.azure.data.cosmos.internal;
 
 import com.azure.data.cosmos.AsyncDocumentClient;
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.ConnectionMode;
 import com.azure.data.cosmos.ConnectionPolicy;
 import com.azure.data.cosmos.ConsistencyLevel;
@@ -237,7 +238,7 @@ public class ConsistencyTests2 extends ConsistencyTestsBase {
         List<Document> documents = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
             Document documentDefinition = getDocumentDefinition();
-            documentDefinition.set(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+            BridgeInternal.setProperty(documentDefinition, UUID.randomUUID().toString(), UUID.randomUUID().toString());
             documents.add(documentDefinition);
         }
 

--- a/sdk/src/test/java/com/azure/data/cosmos/internal/ConsistencyTestsBase.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/internal/ConsistencyTestsBase.java
@@ -230,7 +230,7 @@ public class ConsistencyTestsBase extends TestSuiteBase {
             {
                 Document document2 = new Document();
                 document2.id("test" + UUID.randomUUID().toString());
-                document2.set("customerid", 2);
+                BridgeInternal.setProperty(document2, "customerid", 2);
                 // name link
                 ResourceResponse<Document> document = writeClient.createDocument(BridgeInternal.getAltLink(coll),
                                                                                  document2, null, false)
@@ -244,7 +244,7 @@ public class ConsistencyTestsBase extends TestSuiteBase {
             {
                 Document document2 = new Document();
                 document2.id("test" + UUID.randomUUID().toString());
-                document2.set("customerid", 3);
+                BridgeInternal.setProperty(document2, "customerid", 3);
                 // name link
                 ResourceResponse<Document> document = writeClient.createDocument(BridgeInternal.getAltLink(coll),
                                                                                  document2, null, false)
@@ -689,7 +689,7 @@ public class ConsistencyTestsBase extends TestSuiteBase {
             // Document to lock pause/resume clients
             Document document1 = new Document();
             document1.id("test" + UUID.randomUUID().toString());
-            document1.set("mypk", 1);
+            BridgeInternal.setProperty(document1, "mypk", 1);
             ResourceResponse<Document> childResource1 = writeClient.createDocument(createdCollection.selfLink(), document1, null, true).blockFirst();
             logger.info("Created {} child resource", childResource1.getResource().resourceId());
             assertThat(childResource1.getSessionToken()).isNotNull();
@@ -700,7 +700,7 @@ public class ConsistencyTestsBase extends TestSuiteBase {
             // Document to lock pause/resume clients
             Document document2 = new Document();
             document2.id("test" + UUID.randomUUID().toString());
-            document2.set("mypk", 2);
+            BridgeInternal.setProperty(document2, "mypk", 2);
             ResourceResponse<Document> childResource2 = writeClient.createDocument(createdCollection.selfLink(), document2, null, true).blockFirst();
             assertThat(childResource2.getSessionToken()).isNotNull();
             assertThat(childResource2.getSessionToken().contains(":")).isTrue();

--- a/sdk/src/test/java/com/azure/data/cosmos/internal/SessionTest.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/internal/SessionTest.java
@@ -23,6 +23,7 @@
 package com.azure.data.cosmos.internal;
 
 import com.azure.data.cosmos.AsyncDocumentClient;
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.ConnectionMode;
 import com.azure.data.cosmos.Database;
 import com.azure.data.cosmos.Document;
@@ -154,7 +155,7 @@ public class SessionTest extends TestSuiteBase {
     public void sessionTokenInDocumentRead(boolean isNameBased) throws UnsupportedEncodingException {
         Document document = new Document();
         document.id(UUID.randomUUID().toString());
-        document.set("pk", "pk");
+        BridgeInternal.setProperty(document, "pk", "pk");
         document = spyClient.createDocument(getCollectionLink(isNameBased), document, null, false)
                 .blockFirst()
                 .getResource();

--- a/sdk/src/test/java/com/azure/data/cosmos/internal/TestSuiteBase.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/internal/TestSuiteBase.java
@@ -24,6 +24,7 @@ package com.azure.data.cosmos.internal;
 
 import com.azure.data.cosmos.AsyncDocumentClient;
 import com.azure.data.cosmos.AsyncDocumentClient.Builder;
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.CompositePath;
 import com.azure.data.cosmos.CompositePathSortOrder;
 import com.azure.data.cosmos.ConnectionMode;
@@ -512,11 +513,11 @@ public class TestSuiteBase extends DocumentClientTest {
         includedPath.path("/*");
         Collection<Index> indexes = new ArrayList<>();
         Index stringIndex = Index.Range(DataType.STRING);
-        stringIndex.set("precision", -1);
+        BridgeInternal.setProperty(stringIndex, "precision", -1);
         indexes.add(stringIndex);
 
         Index numberIndex = Index.Range(DataType.NUMBER);
-        numberIndex.set("precision", -1);
+        BridgeInternal.setProperty(numberIndex, "precision", -1);
         indexes.add(numberIndex);
         includedPath.indexes(indexes);
         includedPaths.add(includedPath);

--- a/sdk/src/test/java/com/azure/data/cosmos/internal/query/DocumentProducerTest.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/internal/query/DocumentProducerTest.java
@@ -22,6 +22,7 @@
  */
 package com.azure.data.cosmos.internal.query;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.ConnectionPolicy;
 import com.azure.data.cosmos.CosmosClientException;
 import com.azure.data.cosmos.Document;
@@ -485,12 +486,12 @@ public class DocumentProducerTest {
 
                 Document d = getDocumentDefinition();
                 if (isOrderby) {
-                    d.set(OrderByIntFieldName, orderByFieldInitialVal + RandomUtils.nextInt(0, 3));
-                    d.set(DocumentPartitionKeyRangeIdFieldName, partitionKeyRangeId);
+                    BridgeInternal.setProperty(d, OrderByIntFieldName, orderByFieldInitialVal + RandomUtils.nextInt(0, 3));
+                    BridgeInternal.setProperty(d, DocumentPartitionKeyRangeIdFieldName, partitionKeyRangeId);
                     PartitionKeyRange pkr = mockPartitionKeyRange(partitionKeyRangeId);
 
-                    d.set(DocumentPartitionKeyRangeMinInclusiveFieldName, pkr.getMinInclusive());
-                    d.set(DocumentPartitionKeyRangeMaxExclusiveFieldName, pkr.getMaxExclusive());
+                    BridgeInternal.setProperty(d, DocumentPartitionKeyRangeMinInclusiveFieldName, pkr.getMinInclusive());
+                    BridgeInternal.setProperty(d, DocumentPartitionKeyRangeMaxExclusiveFieldName, pkr.getMaxExclusive());
 
                     QueryItem qi = new QueryItem("{ \"item\": " + Integer.toString(d.getInt(OrderByIntFieldName)) +
                                                          " }");

--- a/sdk/src/test/java/com/azure/data/cosmos/rx/AggregateQueryTests.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/rx/AggregateQueryTests.java
@@ -22,6 +22,7 @@
  */
 package com.azure.data.cosmos.rx;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.CosmosClient;
 import com.azure.data.cosmos.CosmosClientBuilder;
 import com.azure.data.cosmos.CosmosContainer;
@@ -116,15 +117,15 @@ public class AggregateQueryTests extends TestSuiteBase {
         for (int i = 0; i < values.length; i++) {
             CosmosItemProperties d = new CosmosItemProperties();
             d.id(UUID.randomUUID().toString());
-            d.set(partitionKey, values[i]);
+            BridgeInternal.setProperty(d, partitionKey, values[i]);
             docs.add(d);
         }
 
         for (int i = 0; i < numberOfDocsWithSamePartitionKey; i++) {
             CosmosItemProperties d = new CosmosItemProperties();
-            d.set(partitionKey, uniquePartitionKey);
-            d.set("resourceId", Integer.toString(i));
-            d.set(field, i + 1);
+            BridgeInternal.setProperty(d, partitionKey, uniquePartitionKey);
+            BridgeInternal.setProperty(d, "resourceId", Integer.toString(i));
+            BridgeInternal.setProperty(d, field, i + 1);
             d.id(UUID.randomUUID().toString());
             docs.add(d);
         }
@@ -132,7 +133,7 @@ public class AggregateQueryTests extends TestSuiteBase {
         numberOfDocumentsWithNumericId = numberOfDocuments - values.length - numberOfDocsWithSamePartitionKey;
         for (int i = 0; i < numberOfDocumentsWithNumericId; i++) {
             CosmosItemProperties d = new CosmosItemProperties();
-            d.set(partitionKey, i + 1);
+            BridgeInternal.setProperty(d, partitionKey, i + 1);
             d.id(UUID.randomUUID().toString());
             docs.add(d);
         }

--- a/sdk/src/test/java/com/azure/data/cosmos/rx/BackPressureCrossPartitionTest.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/rx/BackPressureCrossPartitionTest.java
@@ -22,6 +22,7 @@
  */
 package com.azure.data.cosmos.rx;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.ClientUnderTestBuilder;
 import com.azure.data.cosmos.CosmosBridgeInternal;
 import com.azure.data.cosmos.CosmosClient;
@@ -89,11 +90,11 @@ public class BackPressureCrossPartitionTest extends TestSuiteBase {
         includedPath.path("/*");
         Collection<Index> indexes = new ArrayList<>();
         Index stringIndex = Index.Range(DataType.STRING);
-        stringIndex.set("precision", -1);
+        BridgeInternal.setProperty(stringIndex, "precision", -1);
         indexes.add(stringIndex);
 
         Index numberIndex = Index.Range(DataType.NUMBER);
-        numberIndex.set("precision", -1);
+        BridgeInternal.setProperty(numberIndex, "precision", -1);
         indexes.add(numberIndex);
         includedPath.indexes(indexes);
         includedPaths.add(includedPath);

--- a/sdk/src/test/java/com/azure/data/cosmos/rx/ChangeFeedTest.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/rx/ChangeFeedTest.java
@@ -300,8 +300,8 @@ public class ChangeFeedTest extends TestSuiteBase {
         String uuid = UUID.randomUUID().toString();
         Document doc = new Document();
         doc.id(uuid);
-        doc.set("mypk", partitionKey);
-        doc.set("prop", uuid);
+        BridgeInternal.setProperty(doc, "mypk", partitionKey);
+        BridgeInternal.setProperty(doc, "prop", uuid);
         return doc;
     }
 

--- a/sdk/src/test/java/com/azure/data/cosmos/rx/CollectionCrudTest.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/rx/CollectionCrudTest.java
@@ -22,6 +22,7 @@
  */
 package com.azure.data.cosmos.rx;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.CompositePath;
 import com.azure.data.cosmos.CompositePathSortOrder;
 import com.azure.data.cosmos.CosmosClient;
@@ -278,8 +279,8 @@ public class CollectionCrudTest extends TestSuiteBase {
 
             CosmosItemProperties document = new CosmosItemProperties();
             document.id("doc");
-            document.set("name", "New Document");
-            document.set("mypk", "mypkValue");
+            BridgeInternal.setProperty(document, "name", "New Document");
+            BridgeInternal.setProperty(document, "mypk", "mypkValue");
             CosmosItem item = createDocument(collection, document);
             CosmosItemRequestOptions options = new CosmosItemRequestOptions();
             options.partitionKey(new PartitionKey("mypkValue"));
@@ -287,7 +288,7 @@ public class CollectionCrudTest extends TestSuiteBase {
             logger.info("Client 1 READ Document Client Side Request Statistics {}", readDocumentResponse.requestDiagnosticsString());
             logger.info("Client 1 READ Document Latency {}", readDocumentResponse.requestLatency());
 
-            document.set("name", "New Updated Document");
+            BridgeInternal.setProperty(document, "name", "New Updated Document");
             CosmosItemResponse upsertDocumentResponse = collection.upsertItem(document).block();
             logger.info("Client 1 Upsert Document Client Side Request Statistics {}", upsertDocumentResponse.requestDiagnosticsString());
             logger.info("Client 1 Upsert Document Latency {}", upsertDocumentResponse.requestLatency());
@@ -299,8 +300,8 @@ public class CollectionCrudTest extends TestSuiteBase {
 
             CosmosItemProperties newDocument = new CosmosItemProperties();
             newDocument.id("doc");
-            newDocument.set("name", "New Created Document");
-            newDocument.set("mypk", "mypk");
+            BridgeInternal.setProperty(newDocument, "name", "New Created Document");
+            BridgeInternal.setProperty(newDocument, "mypk", "mypk");
             createDocument(collection2, newDocument);
 
             readDocumentResponse = client1.getDatabase(dbId).getContainer(collectionId).getItem(newDocument.id(), newDocument.get("mypk")).read().block();

--- a/sdk/src/test/java/com/azure/data/cosmos/rx/DocumentCrudTest.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/rx/DocumentCrudTest.java
@@ -22,6 +22,7 @@
  */
 package com.azure.data.cosmos.rx;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.CosmosClient;
 import com.azure.data.cosmos.CosmosClientBuilder;
 import com.azure.data.cosmos.CosmosClientException;
@@ -39,6 +40,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
+import sun.corba.Bridge;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -87,7 +89,7 @@ public class DocumentCrudTest extends TestSuiteBase {
 
         //Keep size as ~ 1.5MB to account for size of other props
         int size = (int) (ONE_MB * 1.5);
-        docDefinition.set("largeString", StringUtils.repeat("x", size));
+        BridgeInternal.setProperty(docDefinition, "largeString", StringUtils.repeat("x", size));
 
         Mono<CosmosItemResponse> createObservable = container.createItem(docDefinition, new CosmosItemRequestOptions());
 
@@ -105,7 +107,7 @@ public class DocumentCrudTest extends TestSuiteBase {
         for(int i = 0; i < 100; i++) {
             sb.append(i).append("x");
         }
-        docDefinition.set("mypk", sb.toString());
+        BridgeInternal.setProperty(docDefinition, "mypk", sb.toString());
 
         Mono<CosmosItemResponse> createObservable = container.createItem(docDefinition, new CosmosItemRequestOptions());
 
@@ -123,7 +125,7 @@ public class DocumentCrudTest extends TestSuiteBase {
         for(int i = 0; i < 100; i++) {
             sb.append(i).append("x");
         }
-        docDefinition.set("mypk", sb.toString());
+        BridgeInternal.setProperty(docDefinition, "mypk", sb.toString());
 
         CosmosItem createdDocument = TestSuiteBase.createDocument(container, docDefinition);
 
@@ -286,7 +288,7 @@ public class DocumentCrudTest extends TestSuiteBase {
         CosmosItem document = container.createItem(docDefinition, new CosmosItemRequestOptions()).block().item();
 
         String newPropValue = UUID.randomUUID().toString();
-        docDefinition.set("newProp", newPropValue);
+        BridgeInternal.setProperty(docDefinition, "newProp", newPropValue);
 
         CosmosItemRequestOptions options = new CosmosItemRequestOptions();
         options.partitionKey(new PartitionKey(docDefinition.get("mypk")));
@@ -322,7 +324,7 @@ public class DocumentCrudTest extends TestSuiteBase {
         properties = container.createItem(properties, new CosmosItemRequestOptions()).block().properties();
 
         String newPropValue = UUID.randomUUID().toString();
-        properties.set("newProp", newPropValue);
+        BridgeInternal.setProperty(properties, "newProp", newPropValue);
 
         // Replace document
 

--- a/sdk/src/test/java/com/azure/data/cosmos/rx/MultiOrderByQueryTests.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/rx/MultiOrderByQueryTests.java
@@ -23,6 +23,7 @@
 
 package com.azure.data.cosmos.rx;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.CompositePath;
 import com.azure.data.cosmos.CompositePathSortOrder;
 import com.azure.data.cosmos.CosmosClient;
@@ -157,23 +158,23 @@ public class MultiOrderByQueryTests extends TestSuiteBase {
 
                 // Permute all the fields so that there are duplicates with tie breaks
                 CosmosItemProperties numberClone = new CosmosItemProperties(multiOrderByDocumentString);
-                numberClone.set(NUMBER_FIELD, random.nextInt(5));
+                BridgeInternal.setProperty(numberClone, NUMBER_FIELD, random.nextInt(5));
                 numberClone.id(UUID.randomUUID().toString());
                 this.documents.add(numberClone);
 
                 CosmosItemProperties stringClone = new CosmosItemProperties(multiOrderByDocumentString);
-                stringClone.set(STRING_FIELD, Integer.toString(random.nextInt(5)));
+                BridgeInternal.setProperty(stringClone, STRING_FIELD, Integer.toString(random.nextInt(5)));
                 stringClone.id(UUID.randomUUID().toString());
                 this.documents.add(stringClone);
 
                 CosmosItemProperties boolClone = new CosmosItemProperties(multiOrderByDocumentString);
-                boolClone.set(BOOL_FIELD, random.nextInt(2) % 2 == 0);
+                BridgeInternal.setProperty(boolClone, BOOL_FIELD, random.nextInt(2) % 2 == 0);
                 boolClone.id(UUID.randomUUID().toString());
                 this.documents.add(boolClone);
 
                 // Also fuzz what partition it goes to
                 CosmosItemProperties partitionClone = new CosmosItemProperties(multiOrderByDocumentString);
-                partitionClone.set(PARTITION_KEY, random.nextInt(5));
+                BridgeInternal.setProperty(partitionClone, PARTITION_KEY, random.nextInt(5));
                 partitionClone.id(UUID.randomUUID().toString());
                 this.documents.add(partitionClone);
             }
@@ -188,18 +189,18 @@ public class MultiOrderByQueryTests extends TestSuiteBase {
         Random random = new Random();
         CosmosItemProperties document = new CosmosItemProperties();
         document.id(UUID.randomUUID().toString());
-        document.set(NUMBER_FIELD, random.nextInt(5));
-        document.set(NUMBER_FIELD_2, random.nextInt(5));
-        document.set(BOOL_FIELD, (random.nextInt() % 2) == 0);
-        document.set(STRING_FIELD, Integer.toString(random.nextInt(5)));
-        document.set(STRING_FIELD_2, Integer.toString(random.nextInt(5)));
-        document.set(NULL_FIELD, null);
-        document.set(OBJECT_FIELD, "");
-        document.set(ARRAY_FIELD, (new ObjectMapper()).createArrayNode());
-        document.set(SHORT_STRING_FIELD, "a" + random.nextInt(100));
-        document.set(MEDIUM_STRING_FIELD, "a" + random.nextInt(128) + 100);
-        document.set(LONG_STRING_FIELD, "a" + random.nextInt(255) + 128);
-        document.set(PARTITION_KEY, random.nextInt(5));
+        BridgeInternal.setProperty(document, NUMBER_FIELD, random.nextInt(5));
+        BridgeInternal.setProperty(document, NUMBER_FIELD_2, random.nextInt(5));
+        BridgeInternal.setProperty(document, BOOL_FIELD, (random.nextInt() % 2) == 0);
+        BridgeInternal.setProperty(document, STRING_FIELD, Integer.toString(random.nextInt(5)));
+        BridgeInternal.setProperty(document, STRING_FIELD_2, Integer.toString(random.nextInt(5)));
+        BridgeInternal.setProperty(document, NULL_FIELD, null);
+        BridgeInternal.setProperty(document, OBJECT_FIELD, "");
+        BridgeInternal.setProperty(document, ARRAY_FIELD, (new ObjectMapper()).createArrayNode());
+        BridgeInternal.setProperty(document, SHORT_STRING_FIELD, "a" + random.nextInt(100));
+        BridgeInternal.setProperty(document, MEDIUM_STRING_FIELD, "a" + random.nextInt(128) + 100);
+        BridgeInternal.setProperty(document, LONG_STRING_FIELD, "a" + random.nextInt(255) + 128);
+        BridgeInternal.setProperty(document, PARTITION_KEY, random.nextInt(5));
         return document;
     }
 
@@ -278,7 +279,7 @@ public class MultiOrderByQueryTests extends TestSuiteBase {
         // CREATE document with numberField not set.
         // This query would then be invalid.
         CosmosItemProperties documentWithEmptyField = generateMultiOrderByDocument();
-        documentWithEmptyField.remove(NUMBER_FIELD);
+        BridgeInternal.remove(documentWithEmptyField, NUMBER_FIELD);
         documentCollection.createItem(documentWithEmptyField, new CosmosItemRequestOptions()).block();
         String query = "SELECT [root." + NUMBER_FIELD + ",root." + STRING_FIELD + "] FROM root ORDER BY root." + NUMBER_FIELD + " ASC ,root." + STRING_FIELD + " DESC";
         Flux<FeedResponse<CosmosItemProperties>> queryObservable = documentCollection.queryItems(query, feedOptions);

--- a/sdk/src/test/java/com/azure/data/cosmos/rx/TestSuiteBase.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/rx/TestSuiteBase.java
@@ -22,6 +22,7 @@
  */
 package com.azure.data.cosmos.rx;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.CompositePath;
 import com.azure.data.cosmos.CompositePathSortOrder;
 import com.azure.data.cosmos.ConnectionMode;
@@ -512,11 +513,11 @@ public class TestSuiteBase extends CosmosClientTest {
         includedPath.path("/*");
         Collection<Index> indexes = new ArrayList<>();
         Index stringIndex = Index.Range(DataType.STRING);
-        stringIndex.set("precision", -1);
+        BridgeInternal.setProperty(stringIndex, "precision", -1);
         indexes.add(stringIndex);
 
         Index numberIndex = Index.Range(DataType.NUMBER);
-        numberIndex.set("precision", -1);
+        BridgeInternal.setProperty(numberIndex, "precision", -1);
         indexes.add(numberIndex);
         includedPath.indexes(indexes);
         includedPaths.add(includedPath);

--- a/sdk/src/test/java/com/azure/data/cosmos/rx/TokenResolverTest.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/rx/TokenResolverTest.java
@@ -381,10 +381,10 @@ public class TokenResolverTest extends TestSuiteBase {
         String partitionKeyValue = "pk";
         Document document1 = new Document();
         document1.id(id1);
-        document1.set(partitionKey, partitionKeyValue);
+        BridgeInternal.setProperty(document1, partitionKey, partitionKeyValue);
         Document document2 = new Document();
         document2.id(id2);
-        document2.set(partitionKey, partitionKeyValue);
+        BridgeInternal.setProperty(document2, partitionKey, partitionKeyValue);
         try {
             asyncClientWithTokenResolver = buildClient(connectionMode, PermissionMode.ALL);
             OffsetDateTime befTime = OffsetDateTime.now();

--- a/sdk/src/test/java/com/azure/data/cosmos/rx/TopQueryTests.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/rx/TopQueryTests.java
@@ -22,6 +22,7 @@
  */
 package com.azure.data.cosmos.rx;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.CosmosClient;
 import com.azure.data.cosmos.CosmosClientBuilder;
 import com.azure.data.cosmos.CosmosContainer;
@@ -195,16 +196,16 @@ public class TopQueryTests extends TestSuiteBase {
         for (int i = 0; i < 10; i++) {
             CosmosItemProperties d = new CosmosItemProperties();
             d.id(Integer.toString(i));
-            d.set(field, i);
-            d.set(partitionKey, firstPk);
+            BridgeInternal.setProperty(d, field, i);
+            BridgeInternal.setProperty(d, partitionKey, firstPk);
             docs.add(d);
         }
 
         for (int i = 10; i < 20; i++) {
             CosmosItemProperties d = new CosmosItemProperties();
             d.id(Integer.toString(i));
-            d.set(field, i);
-            d.set(partitionKey, secondPk);
+            BridgeInternal.setProperty(d, field, i);
+            BridgeInternal.setProperty(d, partitionKey, secondPk);
             docs.add(d);
         }
     }

--- a/sdk/src/test/java/com/azure/data/cosmos/rx/VeryLargeDocumentQueryTest.java
+++ b/sdk/src/test/java/com/azure/data/cosmos/rx/VeryLargeDocumentQueryTest.java
@@ -22,6 +22,7 @@
  */
 package com.azure.data.cosmos.rx;
 
+import com.azure.data.cosmos.BridgeInternal;
 import com.azure.data.cosmos.CosmosClient;
 import com.azure.data.cosmos.CosmosClientBuilder;
 import com.azure.data.cosmos.CosmosContainer;
@@ -90,7 +91,7 @@ public class VeryLargeDocumentQueryTest extends TestSuiteBase {
 
         //Keep size as ~ 1.999MB to account for size of other props
         int size = (int) (ONE_MB * 1.999);
-        docDefinition.set("largeString", StringUtils.repeat("x", size));
+        BridgeInternal.setProperty(docDefinition, "largeString", StringUtils.repeat("x", size));
 
         Mono<CosmosItemResponse> createObservable = createdCollection.createItem(docDefinition, new CosmosItemRequestOptions());
 


### PR DESCRIPTION
Reduced scope of set and remove method of JsonSerializable from public to package-private.

Created BridgeInternal methods for these. 

Reduced scope of methods returning objectMapper, objectNode, jsonNode, etc. 