### PR TITLE
CFP: fix issue with restarting an existing processor

### DIFF
--- a/sdk/src/main/java/com/azure/data/cosmos/internal/changefeed/implementation/LeaseStoreManagerImpl.java
+++ b/sdk/src/main/java/com/azure/data/cosmos/internal/changefeed/implementation/LeaseStoreManagerImpl.java
@@ -267,9 +267,11 @@ public class LeaseStoreManagerImpl implements LeaseStoreManager, LeaseStoreManag
                 self.requestOptionsFactory.createRequestOptions(lease),
                 serverLease ->
                 {
-                    if (!serverLease.getOwner().equalsIgnoreCase(lease.getOwner())) {
-                        logger.info("Partition {} no need to release lease. The lease was already taken by another host '{}'.", lease.getLeaseToken(), serverLease.getOwner());
-                        throw Exceptions.propagate(new LeaseLostException(lease));
+                    if (serverLease.getOwner() != null) {
+                        if (!serverLease.getOwner().equalsIgnoreCase(lease.getOwner())) {
+                            logger.info("Partition {} no need to release lease. The lease was already taken by another host '{}'.", lease.getLeaseToken(), serverLease.getOwner());
+                            throw Exceptions.propagate(new LeaseLostException(lease));
+                        }
                     }
 
                     serverLease.setOwner(null);

--- a/sdk/src/main/java/com/azure/data/cosmos/internal/changefeed/implementation/PartitionSupervisorImpl.java
+++ b/sdk/src/main/java/com/azure/data/cosmos/internal/changefeed/implementation/PartitionSupervisorImpl.java
@@ -112,7 +112,6 @@ class PartitionSupervisorImpl implements PartitionSupervisor, Closeable {
 
             this.processorCancellation.cancel();
             this.renewerCancellation.cancel();
-            executorService.shutdown();
 
             if (self.processor.getResultException() != null) {
                 throw self.processor.getResultException();


### PR DESCRIPTION
Fix issue with the restarting of the processor; the executor cannot be shutdown since this will stop any future execution using it.