### PR TITLE
Fixed encoding to ensure lower case % encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ hs_err_pid*
 .classpath
 .idea
 *.iml
+*/test-output/
 
 doc
 docs

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2</version>
   </parent>
   
   <artifactId>azure-cosmosdb-benchmark</artifactId>

--- a/commons-test-utils/pom.xml
+++ b/commons-test-utils/pom.xml
@@ -28,7 +28,7 @@ SOFTWARE.
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2</version>
   </parent>
   <artifactId>azure-cosmosdb-commons-test-utils</artifactId>
   <name>Common Test Components for Testing Async SDK for SQL API of Azure Cosmos DB Service</name>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2</version>
   </parent>
   <artifactId>azure-cosmosdb-commons</artifactId>
   <name>Common Components for Async SDK for SQL API of Azure Cosmos DB Service</name>

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/internal/HttpConstants.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/internal/HttpConstants.java
@@ -272,7 +272,7 @@ public class HttpConstants {
         // TODO: FIXME we can use maven plugin for generating a version file
         // @see
         // https://stackoverflow.com/questions/2469922/generate-a-version-java-file-in-maven
-        public static final String SDK_VERSION = "2.5.1";
+        public static final String SDK_VERSION = "2.5.2";
         public static final String SDK_NAME = "cosmosdb-java-sdk";
     }
 

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/HttpUtils.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/HttpUtils.java
@@ -42,14 +42,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class HttpUtils {
 
     private static Logger log = LoggerFactory.getLogger(HttpUtils.class);
+    private static final Pattern URL_PERCENT_ENCODING = Pattern.compile("%[0-9A-Fa-f]{2}");
 
     public static String urlEncode(String url) {
         try {
-            return URLEncoder.encode(url, UrlEncodingInfo.UTF_8).replaceAll(UrlEncodingInfo.PLUS_SYMBOL_ESCAPED, UrlEncodingInfo.SINGLE_SPACE_URI_ENCODING);
+            String encodedString = URLEncoder.encode(url, UrlEncodingInfo.UTF_8).replaceAll(UrlEncodingInfo.PLUS_SYMBOL_ESCAPED, UrlEncodingInfo.SINGLE_SPACE_URI_ENCODING);
+            return toLowerCasePercentEncoding(encodedString);
         } catch (UnsupportedEncodingException e) {
             log.error("failed to encode {}", url, e);
             throw new IllegalArgumentException("failed to encode url " + url, e);
@@ -127,4 +131,16 @@ public class HttpUtils {
         }
         return result;
     }
+    
+    public static String toLowerCasePercentEncoding(String encodedString) {
+        StringBuffer result = new StringBuffer();
+        Matcher percentEncodingMatcher = URL_PERCENT_ENCODING.matcher(encodedString);
+
+        while (percentEncodingMatcher.find()) {
+            percentEncodingMatcher.appendReplacement(result, percentEncodingMatcher.group().toLowerCase());
+        }
+        percentEncodingMatcher.appendTail(result);
+
+        return result.toString();
+    } 
 }

--- a/direct-impl/pom.xml
+++ b/direct-impl/pom.xml
@@ -28,14 +28,14 @@ SOFTWARE.
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-cosmosdb-direct</artifactId>
   <name>Azure Cosmos DB Async SDK Direct Internal Implementation</name>
-  <version>2.5.1</version>
+  <version>2.5.2</version>
   <description>Azure Cosmos DB Async SDK Direct Internal Implementation</description>
   <url>https://docs.microsoft.com/en-us/azure/cosmos-db</url>
   <packaging>jar</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <test.groups>unit</test.groups>
-    <cosmosdb-sdk.version>2.5.1</cosmosdb-sdk.version>
+    <cosmosdb-sdk.version>2.5.2</cosmosdb-sdk.version>
     <guava.version>27.0.1-jre</guava.version>
     <metrics.version>4.0.5</metrics.version>
   </properties>

--- a/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/BarrierRequestHelper.java
+++ b/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/BarrierRequestHelper.java
@@ -112,9 +112,10 @@ public class BarrierRequestHelper {
                         barrierLsnRequest.getHeaders(),
                         originalRequestTokenType,
                         request.properties);
-                authorizationToken = HttpUtils.urlEncode(authorizationToken);
+                if (authorizationToken != null) {
+                    authorizationToken = HttpUtils.urlEncode(authorizationToken);
+                }
                 break;
-
 
             case ResourceToken:
                 authorizationToken = request.getHeaders().get(HttpConstants.HttpHeaders.AUTHORIZATION);

--- a/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/BarrierRequestHelper.java
+++ b/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/BarrierRequestHelper.java
@@ -35,7 +35,6 @@ import com.microsoft.azure.cosmosdb.rx.internal.IAuthorizationTokenProvider;
 import com.microsoft.azure.cosmosdb.rx.internal.RMResources;
 import com.microsoft.azure.cosmosdb.rx.internal.RxDocumentServiceRequest;
 import com.microsoft.azure.cosmosdb.rx.internal.Strings;
-import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Single;
@@ -113,6 +112,7 @@ public class BarrierRequestHelper {
                         barrierLsnRequest.getHeaders(),
                         originalRequestTokenType,
                         request.properties);
+                authorizationToken = HttpUtils.urlEncode(authorizationToken);
                 break;
 
 

--- a/direct-impl/src/test/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/RntbdTransportClientTest.java
+++ b/direct-impl/src/test/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/RntbdTransportClientTest.java
@@ -639,7 +639,7 @@ public final class RntbdTransportClientTest {
                 builder.build()
             );
 
-            builder.put(HttpHeaders.AUTHORIZATION, token);
+            builder.put(HttpHeaders.AUTHORIZATION, HttpUtils.urlEncode(token));
 
             final RxDocumentServiceRequest request = RxDocumentServiceRequest.create(OperationType.Read,
                 ResourceType.DatabaseAccount,

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2</version>
   </parent>
 
   <artifactId>azure-cosmosdb-examples</artifactId>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -28,7 +28,7 @@ SOFTWARE.
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2</version>
   </parent>
   <artifactId>azure-cosmosdb-gateway</artifactId>
   <name>Common Gateway Components for Async SDK for SQL API of Azure Cosmos DB Service</name>

--- a/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/RxClientCollectionCache.java
+++ b/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/caches/RxClientCollectionCache.java
@@ -35,6 +35,7 @@ import com.microsoft.azure.cosmosdb.internal.OperationType;
 import com.microsoft.azure.cosmosdb.internal.PathsHelper;
 import com.microsoft.azure.cosmosdb.internal.ResourceType;
 import com.microsoft.azure.cosmosdb.internal.Utils;
+import com.microsoft.azure.cosmosdb.internal.directconnectivity.HttpUtils;
 import com.microsoft.azure.cosmosdb.rx.internal.AuthorizationTokenType;
 import com.microsoft.azure.cosmosdb.rx.internal.ClearingSessionContainerClientRetryPolicy;
 import com.microsoft.azure.cosmosdb.rx.internal.IAuthorizationTokenProvider;
@@ -104,11 +105,7 @@ public class RxClientCollectionCache extends RxCollectionCache {
                 AuthorizationTokenType.PrimaryMasterKey,
                 properties);
 
-        try {
-            authorizationToken = URLEncoder.encode(authorizationToken, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            return Single.error(new IllegalStateException("Failed to encode authtoken.", e));
-        }
+        authorizationToken = HttpUtils.urlEncode(authorizationToken);
         request.getHeaders().put(HttpConstants.HttpHeaders.AUTHORIZATION, authorizationToken);
 
         if (retryPolicyInstance != null){

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-cosmosdb-parent</artifactId>
-  <version>2.5.1</version>
+  <version>2.5.2</version>
   <packaging>pom</packaging>
   <name>Azure Cosmos DB SQL API</name>
   <description>Java Async SDK (with Reactive Extension RX support) for Azure Cosmos DB SQL API</description>
@@ -64,9 +64,9 @@
     <slf4j.version>1.7.6</slf4j.version>
     <testng.version>6.14.3</testng.version>
     <test.groups>unit</test.groups>
-    <cosmosdb-sdk-direct-impl.version>2.5.1</cosmosdb-sdk-direct-impl.version>
-    <sdk-version>2.5.1</sdk-version>
-    <direct-connectivity-version>2.5.1</direct-connectivity-version>
+    <cosmosdb-sdk-direct-impl.version>2.5.2</cosmosdb-sdk-direct-impl.version>
+    <sdk-version>2.5.2</sdk-version>
+    <direct-connectivity-version>2.5.2</direct-connectivity-version>
     <collectedArtifactsForReleaseLocation>${project.basedir}/target/collectedArtifactsForRelease</collectedArtifactsForReleaseLocation>
     <javadoc.opts/>
   </properties>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2</version>
   </parent>
   <artifactId>azure-cosmosdb</artifactId>
   <name>Async SDK for SQL API of Azure Cosmos DB Service</name>

--- a/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentClientImpl.java
+++ b/sdk/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentClientImpl.java
@@ -79,6 +79,7 @@ import com.microsoft.azure.cosmosdb.internal.SessionContainer;
 import com.microsoft.azure.cosmosdb.internal.UserAgentContainer;
 import com.microsoft.azure.cosmosdb.internal.Utils;
 import com.microsoft.azure.cosmosdb.internal.directconnectivity.GatewayServiceConfigurationReader;
+import com.microsoft.azure.cosmosdb.internal.directconnectivity.HttpUtils;
 import com.microsoft.azure.cosmosdb.internal.directconnectivity.ServerStoreModel;
 import com.microsoft.azure.cosmosdb.internal.directconnectivity.StoreClient;
 import com.microsoft.azure.cosmosdb.internal.directconnectivity.StoreClientFactory;
@@ -1058,11 +1059,7 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
             String authorization = this.getUserAuthorizationToken(
                     resourceName, request.getResourceType(), httpMethod, request.getHeaders(),
                     AuthorizationTokenType.PrimaryMasterKey, request.properties);
-            try {
-                authorization = URLEncoder.encode(authorization, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new IllegalStateException("Failed to encode authtoken.", e);
-            }
+            authorization = HttpUtils.urlEncode(authorization);
             request.getHeaders().put(HttpConstants.HttpHeaders.AUTHORIZATION, authorization);
         }
 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/AuthEncodingTests.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/AuthEncodingTests.java
@@ -1,0 +1,107 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmosdb.rx;
+
+import com.microsoft.azure.cosmosdb.ConnectionMode;
+import com.microsoft.azure.cosmosdb.Document;
+import com.microsoft.azure.cosmosdb.DocumentCollection;
+import com.microsoft.azure.cosmosdb.internal.HttpConstants;
+import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
+import com.microsoft.azure.cosmosdb.rx.TestSuiteBase;
+import com.microsoft.azure.cosmosdb.rx.internal.SpyClientUnderTestFactory;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.protocol.http.client.HttpClientRequest;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AuthEncodingTests extends TestSuiteBase {
+    protected static final int TIMEOUT = 20000;
+
+    private DocumentCollection createdCollection;
+    private SpyClientUnderTestFactory.SpyBaseClass<HttpClientRequest<ByteBuf>> spyClient;
+    private AsyncDocumentClient houseKeepingClient;
+    private ConnectionMode connectionMode;
+    private static final Pattern URL_PERCENT_ENCODING = Pattern.compile("%[0-9A-F]{2}");
+
+    @Factory(dataProvider = "clientBuildersWithDirectSession")
+    public AuthEncodingTests(AsyncDocumentClient.Builder clientBuilder) {
+        super(clientBuilder);
+        this.subscriberValidationTimeout = TIMEOUT;
+    }
+
+    @BeforeClass(groups = { "simple" }, timeOut = SETUP_TIMEOUT)
+    public void beforeClass() throws Exception {
+        createdCollection = SHARED_MULTI_PARTITION_COLLECTION;
+        houseKeepingClient = clientBuilder().build();
+        connectionMode = houseKeepingClient.getConnectionPolicy().getConnectionMode();
+
+        if (connectionMode == ConnectionMode.Direct) {
+            spyClient = SpyClientUnderTestFactory.createDirectHttpsClientUnderTest(clientBuilder());
+        } else {
+            spyClient = SpyClientUnderTestFactory.createClientUnderTest(clientBuilder());
+        }
+    }
+
+    @AfterClass(groups = { "simple" }, timeOut = SHUTDOWN_TIMEOUT, alwaysRun = true)
+    public void afterClass() {
+        safeClose(houseKeepingClient);
+        safeClose(spyClient);
+    }
+
+    @BeforeMethod(groups = { "simple" }, timeOut = SETUP_TIMEOUT)
+    public void beforeTest(Method method) {
+        spyClient.clearCapturedRequests();
+    }
+
+    private List<String> getAuthTokenInRequests() {
+        return spyClient.getCapturedRequests().stream()
+                .map(r -> r.getHeaders().get(HttpConstants.HttpHeaders.AUTHORIZATION)).collect(Collectors.toList());
+    }
+
+    @Test(groups = { "simple" }, timeOut = TIMEOUT * 100000)
+    public void validateLowerCasePercentEncodingOfAuthorizationHeader() {
+        spyClient.readCollection(createdCollection.getSelfLink(), null).toBlocking().single();
+        spyClient.createDocument(createdCollection.getSelfLink(), new Document(), null, false).toBlocking().single().getResource();
+
+        for (String authHeader : getAuthTokenInRequests()) {
+            Matcher percentEncodingMatcher = URL_PERCENT_ENCODING.matcher(authHeader);
+            while (percentEncodingMatcher.find()) {
+                String matchingSubstring = percentEncodingMatcher.group(); 
+                assertThat(matchingSubstring).isEqualTo(matchingSubstring.toLowerCase());
+            }
+        }
+    }
+}


### PR DESCRIPTION
URL encoded auth key will not contain charatcers like "%2B" but instead "%2b". This is needed since the backend does case sensitive decoding. 