### PR TITLE
bugfix: try other regions on multimaster for query when the current region is unavailable

### DIFF
--- a/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ClientRetryPolicy.java
+++ b/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ClientRetryPolicy.java
@@ -34,6 +34,7 @@ import rx.Single;
 
 import java.net.URL;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * While this class is public, but it is not part of our published public APIs.
@@ -60,6 +61,7 @@ public class ClientRetryPolicy implements IDocumentClientRetryPolicy {
     private URL locationEndpoint;
     private RetryContext retryContext;
     private ClientSideRequestStatistics clientSideRequestStatistics;
+    private AtomicInteger cnt = new AtomicInteger(0);
 
     public ClientRetryPolicy(GlobalEndpointManager globalEndpointManager,
                              boolean enableEndpointDiscovery,
@@ -79,6 +81,12 @@ public class ClientRetryPolicy implements IDocumentClientRetryPolicy {
 
     @Override
     public Single<ShouldRetryResult> shouldRetry(Exception e) {
+        logger.debug("retry count {}, isReadRequest {}, canUseMultipleWriteLocations {}, due to failure {}",
+                    cnt.incrementAndGet(),
+                    isReadRequest,
+                    canUseMultipleWriteLocations,
+                    e);
+
         if (this.locationEndpoint == null) {
             // on before request is not invoked because Document Service Request creation failed.
             logger.error("locationEndpoint is null because ClientRetryPolicy::onBeforeRequest(.) is not invoked, " +

--- a/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/DocumentProducer.java
+++ b/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/DocumentProducer.java
@@ -151,10 +151,14 @@ class DocumentProducer<T extends Resource> {
             IDocumentClientRetryPolicy retryPolicy = null;
             if (createRetryPolicyFunc != null) {
                 retryPolicy = createRetryPolicyFunc.call();
-                retryPolicy.onBeforeSendRequest(request);
             }
+            final IDocumentClientRetryPolicy finalRetryPolicy = retryPolicy;
+
             return ObservableHelper.inlineIfPossibleAsObs(
                     () -> {
+                        if (finalRetryPolicy != null) {
+                            finalRetryPolicy.onBeforeSendRequest(request);
+                        }
                         ++retries;
                         return executeRequestFunc.call(request);
                     }, retryPolicy);

--- a/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/QueryPlanRetriever.java
+++ b/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/QueryPlanRetriever.java
@@ -31,8 +31,6 @@ import com.microsoft.azure.cosmosdb.internal.query.PartitionedQueryExecutionInfo
 import com.microsoft.azure.cosmosdb.rx.internal.BackoffRetryUtility;
 import com.microsoft.azure.cosmosdb.rx.internal.IDocumentClientRetryPolicy;
 import com.microsoft.azure.cosmosdb.rx.internal.RxDocumentServiceRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import rx.Single;
 import rx.functions.Func1;
 


### PR DESCRIPTION
to ensure for in fly requests we retry on the other regions `ClientRetryPolicy#onBeforeRequest` should be invoked.

This was missing in QueryPlanRetrieval and DocumentProducer.