### PR TITLE
2.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Java SDK for SQL API of Azure Cosmos DB
-[![Maven Central](https://img.shields.io/maven-central/v/com.microsoft.azure/azure-cosmosdb.svg)](https://search.maven.org/artifact/com.microsoft.azure/azure-cosmosdb/2.4.3/jar)
+
+[![Maven Central](https://img.shields.io/maven-central/v/com.microsoft.azure/azure-cosmosdb.svg)](https://search.maven.org/artifact/com.microsoft.azure/azure-cosmosdb/)
 [![Build Status](https://api.travis-ci.org/Azure/azure-cosmosdb-java.svg?branch=master)](https://travis-ci.org/Azure/azure-cosmosdb-java)
 [![Known Vulnerabilities](https://snyk.io/test/github/Azure/azure-cosmosdb-java/badge.svg?targetFile=sdk%2Fpom.xml)](https://snyk.io/test/github/Azure/azure-cosmosdb-java?targetFile=sdk%2Fpom.xml)
+
 <!--[![Coverage Status](https://img.shields.io/codecov/c/github/Azure/azure-cosmosdb-java.svg)](https://codecov.io/gh/Azure/azure-cosmosdb-java)
 ![](https://img.shields.io/github/issues/azure/azure-cosmosdb-java.svg)
  -->
- 
+
 <!-- TOC depthFrom:2 depthTo:2 withLinks:1 updateOnSave:1 orderedList:0 -->
 
 - [Consuming the official Microsoft Azure Cosmos DB Java SDK](#consuming-the-official-microsoft-azure-cosmos-db-java-sdk)
@@ -22,13 +24,12 @@
 
 <!-- /TOC -->
 
-
 ## Consuming the official Microsoft Azure Cosmos DB Java SDK
 
 This project provides a SDK library in Java for interacting with [SQL API](https://docs.microsoft.com/en-us/azure/cosmos-db/sql-api-sql-query) of [Azure Cosmos DB
 Database Service](https://azure.microsoft.com/en-us/services/cosmos-db/). This project also includes samples, tools, and utilities.
 
-Jar dependency binary information for maven and gradle can be found here at [maven]( https://mvnrepository.com/artifact/com.microsoft.azure/azure-cosmosdb/2.4.3).
+Jar dependency binary information for maven and gradle can be found here at [maven](https://mvnrepository.com/artifact/com.microsoft.azure/azure-cosmosdb/).
 
 For example, using maven, you can add the following dependency to your maven pom file:
 
@@ -36,39 +37,39 @@ For example, using maven, you can add the following dependency to your maven pom
 <dependency>
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-cosmosdb</artifactId>
-  <version>2.4.3</version>
+  <version>2.6.1</version>
 </dependency>
 ```
 
-
-
 Useful links:
+
 - [Sample Get Started APP](https://github.com/Azure-Samples/azure-cosmos-db-sql-api-async-java-getting-started)
-- [Introduction to Resource Model of Azure Cosmos DB Service]( https://docs.microsoft.com/en-us/azure/cosmos-db/sql-api-resources)
+- [Introduction to Resource Model of Azure Cosmos DB Service](https://docs.microsoft.com/en-us/azure/cosmos-db/sql-api-resources)
 - [Introduction to SQL API of Azure Cosmos DB Service](https://docs.microsoft.com/en-us/azure/cosmos-db/sql-api-sql-query)
 - [SDK JavaDoc API](https://azure.github.io/azure-cosmosdb-java/2.4.0/com/microsoft/azure/cosmosdb/rx/AsyncDocumentClient.html)
 - [RxJava Observable JavaDoc API](http://reactivex.io/RxJava/1.x/javadoc/rx/Observable.html)
 - [SDK FAQ](faq/)
 
 ## Prerequisites
-* Java Development Kit 8
-* An active Azure account. If you don't have one, you can sign up for a [free account](https://azure.microsoft.com/free/). Alternatively, you can use the [Azure Cosmos DB Emulator](https://azure.microsoft.com/documentation/articles/documentdb-nosql-local-emulator) for development and testing. As emulator https certificate is self signed, you need to import its certificate to java trusted cert store as [explained here](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator-export-ssl-certificates)
-* (Optional) SLF4J is a logging facade.
-* (Optional) [SLF4J binding](http://www.slf4j.org/manual.html) is used to associate a specific logging framework with SLF4J.
-* (Optional) Maven
+
+- Java Development Kit 8
+- An active Azure account. If you don't have one, you can sign up for a [free account](https://azure.microsoft.com/free/). Alternatively, you can use the [Azure Cosmos DB Emulator](https://azure.microsoft.com/documentation/articles/documentdb-nosql-local-emulator) for development and testing. As emulator https certificate is self signed, you need to import its certificate to java trusted cert store as [explained here](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator-export-ssl-certificates)
+- (Optional) SLF4J is a logging facade.
+- (Optional) [SLF4J binding](http://www.slf4j.org/manual.html) is used to associate a specific logging framework with SLF4J.
+- (Optional) Maven
 
 SLF4J is only needed if you plan to use logging, please also download an SLF4J binding which will link the SLF4J API with the logging implementation of your choice. See the [SLF4J user manual](http://www.slf4j.org/manual.html) for more information.
 
-
 ## API Documentation
+
 Javadoc is available [here](https://azure.github.io/azure-cosmosdb-java/2.4.0/com/microsoft/azure/cosmosdb/rx/AsyncDocumentClient.html).
 
 The SDK provide Reactive Extension Observable based async API. You can read more about RxJava and [Observable APIs here](http://reactivex.io/RxJava/1.x/javadoc/rx/Observable.html).
 
-
 ## Usage Code Sample
 
 Code Sample for creating a Document:
+
 ```java
 import com.microsoft.azure.cosmosdb.rx.*;
 import com.microsoft.azure.cosmosdb.*;
@@ -77,44 +78,44 @@ ConnectionPolicy policy = new ConnectionPolicy();
 policy.setConnectionMode(ConnectionMode.Direct);
 
 AsyncDocumentClient asyncClient = new AsyncDocumentClient.Builder()
-				.withServiceEndpoint(HOST)
-				.withMasterKeyOrResourceToken(MASTER_KEY)
-				.withConnectionPolicy(policy)
-				.withConsistencyLevel(ConsistencyLevel.Eventual)
-				.build();
+                .withServiceEndpoint(HOST)
+                .withMasterKeyOrResourceToken(MASTER_KEY)
+                .withConnectionPolicy(policy)
+                .withConsistencyLevel(ConsistencyLevel.Eventual)
+                .build();
 
 Document doc = new Document(String.format("{ 'id': 'doc%d', 'counter': '%d'}", 1, 1));
 
 Observable<ResourceResponse<Document>> createDocumentObservable =
-	asyncClient.createDocument(collectionLink, doc, null, false);
-	createDocumentObservable
-	            .single()           // we know there will be one response
-	            .subscribe(
+    asyncClient.createDocument(collectionLink, doc, null, false);
+    createDocumentObservable
+                .single()           // we know there will be one response
+                .subscribe(
 
-	                documentResourceResponse -> {
-	                    System.out.println(documentResourceResponse.getRequestCharge());
-	                },
+                    documentResourceResponse -> {
+                        System.out.println(documentResourceResponse.getRequestCharge());
+                    },
 
-	                error -> {
-	                    System.err.println("an error happened: " + error.getMessage());
-	                });
+                    error -> {
+                        System.err.println("an error happened: " + error.getMessage());
+                    });
 ```
 
 We have a get started sample app available [here](https://github.com/Azure-Samples/azure-cosmos-db-sql-api-async-java-getting-started).
 
 Also We have more examples in form of standalone unit tests in [examples project](examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples).
 
-
 ## Guide for Prod
+
 To achieve better performance and higher throughput there are a few tips that are helpful to follow:
 
 ### Use Appropriate Scheduler (Avoid stealing Eventloop IO Netty threads)
+
 SDK uses [netty](https://netty.io/) for non-blocking IO. The SDK uses a fixed number of IO netty eventloop threads (as many CPU cores your machine has) for executing IO operations.
 
- The Observable returned by API emits the result on one of the shared IO eventloop netty threads. So it is important to not block the shared IO eventloop netty threads. Doing CPU intensive work or blocking operation on the IO eventloop netty thread may cause deadlock or significantly reduce SDK throughput.
+The Observable returned by API emits the result on one of the shared IO eventloop netty threads. So it is important to not block the shared IO eventloop netty threads. Doing CPU intensive work or blocking operation on the IO eventloop netty thread may cause deadlock or significantly reduce SDK throughput.
 
 For example the following code executes a cpu intensive work on the eventloop IO netty thread:
-
 
 ```java
 Observable<ResourceResponse<Document>> createDocObs = asyncDocumentClient.createDocument(
@@ -150,18 +151,19 @@ subscribe(
 ```
 
 Based on the type of your work you should use the appropriate existing RxJava Scheduler for your work. Please read here
-[``Schedulers``](http://reactivex.io/RxJava/1.x/javadoc/rx/schedulers/Schedulers.html).
-
+[`Schedulers`](http://reactivex.io/RxJava/1.x/javadoc/rx/schedulers/Schedulers.html).
 
 ### Disable netty's logging
+
 Netty library logging is very chatty and need to be turned off (suppressing log in the configuration may not be enough) to avoid additional CPU costs.
-If you are not in debugging mode disable netty's logging altogether. So if you are using log4j to remove the additional CPU costs incurred by ``org.apache.log4j.Category.callAppenders()`` from netty add the following line to your codebase:
+If you are not in debugging mode disable netty's logging altogether. So if you are using log4j to remove the additional CPU costs incurred by `org.apache.log4j.Category.callAppenders()` from netty add the following line to your codebase:
 
 ```java
 org.apache.log4j.Logger.getLogger("io.netty").setLevel(org.apache.log4j.Level.OFF);
 ```
 
 ### OS Open files Resource Limit
+
 Some Linux systems (like Redhat) have an upper limit on the number of open files and so the total number of connections. Run the following to view the current limits:
 
 ```bash
@@ -175,23 +177,27 @@ Open the limits.conf file:
 ```bash
 vim /etc/security/limits.conf
 ```
+
 Add/modify the following lines:
 
-```
+```bash
 * - nofile 100000
 ```
 
 ### Use native SSL implementation for netty
+
 Netty can use OpenSSL directly for SSL implementation stack to achieve better performance.
 In the absence of this configuration netty will fall back to Java's default SSL implementation.
 
 on Ubuntu:
+
 ```bash
 sudo apt-get install openssl
 sudo apt-get install libapr1
 ```
 
 and add the following dependency to your project maven dependencies:
+
 ```xml
 <dependency>
   <groupId>io.netty</groupId>
@@ -201,17 +207,17 @@ and add the following dependency to your project maven dependencies:
 </dependency>
 ```
 
-For other platforms (Redhat, Windows, Mac, etc) please refer to these instructions https://netty.io/wiki/forked-tomcat-native.html
+For other platforms (Redhat, Windows, Mac, etc) please refer to the instructions on [netty's wiki](https://netty.io/wiki/forked-tomcat-native.html).
 
 ### Common Perf Tips
+
 There is a set of common perf tips written for our sync SDK. The majority of them also apply to the async SDK. It is available [here](https://docs.microsoft.com/en-us/azure/cosmos-db/performance-tips-java).
 
 ## Future, CompletableFuture, and ListenableFuture
 
 The SDK provide Reactive Extension (Rx) [Observable](http://reactivex.io/RxJava/1.x/javadoc/rx/Observable.html) based async API.
 
-
-RX API has advantages over Future based APIs. But if you wish to use ``Future`` you can translate Observables to Java native Futures:
+RX API has advantages over Future based APIs. But if you wish to use `Future` you can translate [Observables to Java native Futures](https://dzone.com/articles/converting-between):
 
 ```java
 // You can convert an Observable to a ListenableFuture.
@@ -233,15 +239,14 @@ ListenableFuture<ResourceResponse<Document>> listenableFuture =
 ResourceResponse<Document> rrd = listenableFuture.get();
 ```
 
-For this to work you will need [RxJava Guava library dependency ](https://mvnrepository.com/artifact/io.reactivex/rxjava-guava/1.0.3). More information available here https://github.com/ReactiveX/RxJavaGuava.
-
-You can see more details on how to convert Observables to Futures here:
-https://dzone.com/articles/converting-between
+For this to work you will need [RxJava Guava library dependency](https://mvnrepository.com/artifact/io.reactivex/rxjava-guava/1.0.3). More information available on [RxJavaGuava's GitHub](https://github.com/ReactiveX/RxJavaGuava).
 
 ## Checking out the Source Code
+
 The SDK is open source and is available here [sdk](sdk/).
 
- Clone the Repo
+Clone the Repo
+
 ```bash
 git clone https://github.com/Azure/azure-cosmosdb-java.git
 cd azure-cosmosdb-java
@@ -249,7 +254,7 @@ cd azure-cosmosdb-java
 
 ### How to Build from Command Line
 
-* Run the following maven command to build:
+Run the following maven command to build:
 
 ```bash
 maven clean package -DskipTests
@@ -265,25 +270,27 @@ mvn test -DACCOUNT_HOST="https://REPLACE_ME_WITH_YOURS.documents.azure.com:443/"
 
 ### Import into Intellij or Eclipse
 
-* Load the main parent project pom file in Intellij/Eclipse (That should automatically load examples).
-* For running the samples you need a proper Azure Cosmos DB Endpoint. The endpoints are picked up from [TestConfigurations.java](examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/TestConfigurations.java). There is a similar endpoint config file for the sdk tests [here](sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TestConfigurations.java).
-* You can pass your endpoint credentials as VM Arguments in Eclipse JUnit Run Config:
-```bash
- -DACCOUNT_HOST="https://REPLACE_ME.documents.azure.com:443/" -DACCOUNT_KEY="REPLACE_ME"
- ```
-* or you can simply put your endpoint credentials in TestConfigurations.java
-* The SDK tests are written using TestNG framework, if you use Eclipse you may have to
+- Load the main parent project pom file in Intellij/Eclipse (That should automatically load examples).
+- For running the samples you need a proper Azure Cosmos DB Endpoint. The endpoints are picked up from [TestConfigurations.java](examples/src/test/java/com/microsoft/azure/cosmosdb/rx/examples/TestConfigurations.java). There is a similar endpoint config file for the sdk tests [here](sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TestConfigurations.java).
+- You can pass your endpoint credentials as VM Arguments in Eclipse JUnit Run Config:
+
+  ```bash
+   -DACCOUNT_HOST="https://REPLACE_ME.documents.azure.com:443/" -DACCOUNT_KEY="REPLACE_ME"
+  ```
+
+- or you can simply put your endpoint credentials in TestConfigurations.java
+- The SDK tests are written using TestNG framework, if you use Eclipse you may have to
   add TestNG plugin to your eclipse IDE as explained [here](http://testng.org/doc/eclipse.html).
   Intellij has builtin support for TestNG.
-* Now you can run the tests in your Intellij/Eclipse IDE.
-
+- Now you can run the tests in your Intellij/Eclipse IDE.
 
 ## FAQ
+
 We have a frequently asked questions which is maintained [here](faq/).
 
 ## Release changes
-Release changelog is available [here](changelog/).
 
+Release changelog is available [here](changelog/).
 
 ## Contribution and Feedback
 
@@ -295,7 +302,7 @@ We have [travis build CI](https://travis-ci.org/Azure/azure-cosmosdb-java) which
 
 If you encounter any bugs with the SDK please file an [issue](https://github.com/Azure/azure-cosmosdb-java/issues) in the Issues section of the project.
 
-
 ## License
+
 MIT License
 Copyright (c) 2018 Copyright (c) Microsoft Corporation

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.1</version>
   </parent>
   
   <artifactId>azure-cosmosdb-benchmark</artifactId>

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,92 +1,109 @@
-## Changelog
+# Changelog
 
-### 2.6.0
+## 2.6.1
 
-* Retrieving query info using new query plan retriever ([#111](https://github.com/Azure/azure-cosmosdb-java/commit/6cdbc90386a343484f37c67bec5ec6321729b60a)) 
-* Offset limit query support ([#234](https://github.com/Azure/azure-cosmosdb-java/commit/65606c714a6e8019e52889a8b3d49e2a5e0f6a02))  
+- Multimaster regional failover fixes for query logic ([#245](https://github.com/Azure/azure-cosmosdb-java/commit/104b4a3b30ffd7c8add01096ce6a9b6e7a3f6318))
+- jackson-databind 2.9.9.3 update ([#244](https://github.com/Azure/azure-cosmosdb-java/commit/f8e60604d9e2edb0b3bd56ec7909d249de47af50))
+- Direct TCP fixes (memory, perf) & metrics interface ([#242](https://github.com/Azure/azure-cosmosdb-java/commit/61562cd16845e2b249a1d91374797faa3469295f))
 
-### 2.5.1
+## 2.6.0
 
-* Fixing executeStoredProcedureInternal to use client retry policy ([#210](https://github.com/Azure/azure-cosmosdb-java/commit/eb99c15c930a7f3a413445a9e257504468329710))
+- Retrieving query info using new query plan retriever ([#111](https://github.com/Azure/azure-cosmosdb-java/commit/6cdbc90386a343484f37c67bec5ec6321729b60a))
+- Offset limit query support ([#234](https://github.com/Azure/azure-cosmosdb-java/commit/65606c714a6e8019e52889a8b3d49e2a5e0f6a02))
 
-### 2.5.0
+## 2.5.1
 
-* TCP transport enabled by default
-* TCP transport improvements
-* Lots of testing improvements
+- Fixing executeStoredProcedureInternal to use client retry policy ([#210](https://github.com/Azure/azure-cosmosdb-java/commit/eb99c15c930a7f3a413445a9e257504468329710))
 
-### 2.4.6
+## 2.5.0
 
-* memory improvements
+- TCP transport enabled by default
+- TCP transport improvements
+- Lots of testing improvements
 
-### 2.4.5
+## 2.4.6
 
-* Added support for Hash v2 ([#96](https://github.com/Azure/azure-cosmosdb-java/commit/f780e2d3210fbf875afcdd5e245877a49f7697ee))
-* Open source direct connectivity implementation ([#94](https://github.com/Azure/azure-cosmosdb-java/commit/81a56e9506827e647253b1b6ae39f95a7aee37a3)) 
+- memory improvements
 
-### 2.4.4
+## 2.4.5
 
+- Added support for Hash v2 ([#96](https://github.com/Azure/azure-cosmosdb-java/commit/f780e2d3210fbf875afcdd5e245877a49f7697ee))
+- Open source direct connectivity implementation ([#94](https://github.com/Azure/azure-cosmosdb-java/commit/81a56e9506827e647253b1b6ae39f95a7aee37a3))
 
-### 2.4.3
-* Fixed resource leak issue on closing client
+## 2.4.4
 
-### 2.4.2
-* Fixed bugs in continuation token support for cross partition queries
+- misc fixes
 
-### 2.4.1
-* Fixed some bugs in Direct mode.
-* Improved logging in Direct mode.
-* Improved connection management.
+## 2.4.3
 
-### 2.4.0
-* Direct GA.
-* Added support for QueryMetrics.
-* Changed the APIs accepting java.util.Collection for which order is important to accept java.util.List instead. Now ConnectionPolicy#getPreferredLocations(), JsonSerialization, and PartitionKey(.) accept List.
+- Fixed resource leak issue on closing client
 
-### 2.4.0-beta1
+## 2.4.2
 
-* Added support for Direct Https.
-* Changed the APIs accepting java.util.Collection for which order is important to accept java.util.List instead.
-  Now ConnectionPolicy#getPreferredLocations(), JsonSerialization, and PartitionKey(.) accept List. 
-* Fixed a Session bug for Document query in Gateway mode.
-* Upgraded dependencies (netty 0.4.20 [github #79](https://github.com/Azure/azure-cosmosdb-java/issues/79), RxJava 1.3.8).
+- Fixed bugs in continuation token support for cross partition queries
 
-### 2.3.1
+## 2.4.1
 
-* Fix handling very large query responses.
-* Fix resource token handling when instantiating client ([github #78](https://github.com/Azure/azure-cosmosdb-java/issues/78)).
-* Upgraded vulnerable dependency jackson-databind ([github #77](https://github.com/Azure/azure-cosmosdb-java/pull/77)). 
+- Fixed some bugs in Direct mode.
+- Improved logging in Direct mode.
+- Improved connection management.
 
-### 2.3.0
+## 2.4.0
 
-* Fixed a resource leak bug.
-* Added support for MultiPolygon
-* Added support for custom headers in RequestOptions.
+- Direct GA.
+- Added support for QueryMetrics.
+- Changed the APIs accepting java.util.Collection for which order is important to accept java.util.List instead. Now ConnectionPolicy#getPreferredLocations(), JsonSerialization, and PartitionKey(.) accept List.
 
-### 2.2.2
-* Fixed a packaging bug.
+## 2.4.0-beta1
 
-### 2.2.1
-* Fixed a NPE bug in write retry path.
-* Fixed a NPE bug in endpoint management.
-* Upgraded vulnerable dependencies ([github #68](https://github.com/Azure/azure-cosmosdb-java/issues/68)).
-* Added support for Netty network logging for troubleshooting.
+- Added support for Direct Https.
+- Changed the APIs accepting java.util.Collection for which order is important to accept java.util.List instead.
+  Now ConnectionPolicy#getPreferredLocations(), JsonSerialization, and PartitionKey(.) accept List.
+- Fixed a Session bug for Document query in Gateway mode.
+- Upgraded dependencies (netty 0.4.20 [github #79](https://github.com/Azure/azure-cosmosdb-java/issues/79), RxJava 1.3.8).
 
-### 2.2.0
-* Added support for Multi-region write.
+## 2.3.1
 
-### 2.1.0
-* Added support for Proxy.
-* Added support for resource token authorization.
-* Fixed a bug in handling large partition keys ([github #63](https://github.com/Azure/azure-cosmosdb-java/issues/63)).
-* Documentation improved.
-* SDK restructured into more granular modules.
+- Fix handling very large query responses.
+- Fix resource token handling when instantiating client ([github #78](https://github.com/Azure/azure-cosmosdb-java/issues/78)).
+- Upgraded vulnerable dependency jackson-databind ([github #77](https://github.com/Azure/azure-cosmosdb-java/pull/77)).
 
-### 2.0.1
+## 2.3.0
+
+- Fixed a resource leak bug.
+- Added support for MultiPolygon
+- Added support for custom headers in RequestOptions.
+
+## 2.2.2
+
+- Fixed a packaging bug.
+
+## 2.2.1
+
+- Fixed a NPE bug in write retry path.
+- Fixed a NPE bug in endpoint management.
+- Upgraded vulnerable dependencies ([github #68](https://github.com/Azure/azure-cosmosdb-java/issues/68)).
+- Added support for Netty network logging for troubleshooting.
+
+## 2.2.0
+
+- Added support for Multi-region write.
+
+## 2.1.0
+
+- Added support for Proxy.
+- Added support for resource token authorization.
+- Fixed a bug in handling large partition keys ([github #63](https://github.com/Azure/azure-cosmosdb-java/issues/63)).
+- Documentation improved.
+- SDK restructured into more granular modules.
+
+## 2.0.1
+
 - Fixed a bug for non-english locales ([github #51](https://github.com/Azure/azure-cosmosdb-java/issues/51)).
 - Added helper methods for Conflict resource.
 
-### 2.0.0
+## 2.0.0
+
 - Replaced org.json dependency by jackson due to performance reasons and licensing ([github #29](https://github.com/Azure/azure-cosmosdb-java/issues/29)).
 - Removed deprecated OfferV2 class.
 - Added accessor method to Offer class for throughput content.
@@ -96,7 +113,8 @@
 - Removed JsonSerializable subclasses' constructors with org.json.JSONObject arg.
 - JsonSerializable.toJson (SerializationFormattingPolicy.Indented) now uses two spaces for indentation.
 
-### 1.0.2
+## 1.0.2
+
 - Added support for Unique Index Policy.
 - Added support for limiting response continuation token size in feed options.
 - Added support for Partition Split in Cross Partition Query.
@@ -108,7 +126,8 @@
 - The metadata description in pom file updated to be inline with the rest of documentation.
 - Syntax improvement ([github #41](https://github.com/Azure/azure-cosmosdb-java/issues/41)), ([github #40](https://github.com/Azure/azure-cosmosdb-java/issues/40)).
 
-### 1.0.1
+## 1.0.1
+
 - Added back-pressure support in query.
 - Added support for partition key range id in query.
 - Changed to allow larger continuation token in request header (bugfix github #24).
@@ -118,21 +137,24 @@
 - Added more benchmarking scenarios.
 - Fixed java header files for proper javadoc generation.
 
-### 1.0.0
-- Release 1.0.0 has fully end to end support for non-blocking IO using netty library in Gateway mode.
-- Dependency on ``azure-documentdb`` SDK removed.
-- Artifact id changed to ``azure-cosmosdb`` from ``azure-documentdb-rx`` in 0.9.0-rc2.
-- Java package name changed to ``com.microsoft.azure.cosmosdb`` from ``com.microsoft.azure.documentdb`` in 0.9.0-rc2.
+## 1.0.0
 
-### 0.9.0-rc2
-- ``FeedResponsePage`` renamed to ``FeedReponse``
-- Some minor modifications to ``ConnectionPolicy`` configuration.
-All time fields and methods in ConnectionPolicy suffixed with "InMillis" to be more precise of the time unit.
-- ``ConnectionPolicy#setProxy()`` removed.
-- ``FeedOptions#pageSize`` renamed to
-``FeedOptions#maxItemCount``
+- Release 1.0.0 has fully end to end support for non-blocking IO using netty library in Gateway mode.
+- Dependency on `azure-documentdb` SDK removed.
+- Artifact id changed to `azure-cosmosdb` from `azure-documentdb-rx` in 0.9.0-rc2.
+- Java package name changed to `com.microsoft.azure.cosmosdb` from `com.microsoft.azure.documentdb` in 0.9.0-rc2.
+
+## 0.9.0-rc2
+
+- `FeedResponsePage` renamed to `FeedReponse`
+- Some minor modifications to `ConnectionPolicy` configuration.
+  All time fields and methods in ConnectionPolicy suffixed with "InMillis" to be more precise of the time unit.
+- `ConnectionPolicy#setProxy()` removed.
+- `FeedOptions#pageSize` renamed to
+  `FeedOptions#maxItemCount`
 - Release 1.0.0 deprecates 0.9.x releases.
 
-### 0.9.0-rc1
-- First release of ``azure-documentdb-rx`` SDK.
-- CRUD Document API fully non-blocking using netty. Query async API implemented as a wrapper using blocking SDK ``azure-documentdb``.
+## 0.9.0-rc1
+
+- First release of `azure-documentdb-rx` SDK.
+- CRUD Document API fully non-blocking using netty. Query async API implemented as a wrapper using blocking SDK `azure-documentdb`.

--- a/commons-test-utils/pom.xml
+++ b/commons-test-utils/pom.xml
@@ -28,7 +28,7 @@ SOFTWARE.
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.1</version>
   </parent>
   <artifactId>azure-cosmosdb-commons-test-utils</artifactId>
   <name>Common Test Components for Testing Async SDK for SQL API of Azure Cosmos DB Service</name>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.1</version>
   </parent>
   <artifactId>azure-cosmosdb-commons</artifactId>
   <name>Common Components for Async SDK for SQL API of Azure Cosmos DB Service</name>

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/internal/HttpConstants.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/internal/HttpConstants.java
@@ -275,7 +275,7 @@ public class HttpConstants {
         // TODO: FIXME we can use maven plugin for generating a version file
         // @see
         // https://stackoverflow.com/questions/2469922/generate-a-version-java-file-in-maven
-        public static final String SDK_VERSION = "2.6.0";
+        public static final String SDK_VERSION = "2.6.1";
         public static final String SDK_NAME = "cosmosdb-java-sdk";
         public static final String QUERY_VERSION = "1.0";
     }

--- a/direct-impl/pom.xml
+++ b/direct-impl/pom.xml
@@ -28,7 +28,7 @@ SOFTWARE.
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-cosmosdb-direct</artifactId>
   <name>Azure Cosmos DB Async SDK Direct Internal Implementation</name>
-  <version>2.6.1-SNAPSHOT</version>
+  <version>2.6.1</version>
   <description>Azure Cosmos DB Async SDK Direct Internal Implementation</description>
   <url>https://docs.microsoft.com/en-us/azure/cosmos-db</url>
   <packaging>jar</packaging>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.1</version>
   </parent>
 
   <artifactId>azure-cosmosdb-examples</artifactId>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -28,7 +28,7 @@ SOFTWARE.
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.1</version>
   </parent>
   <artifactId>azure-cosmosdb-gateway</artifactId>
   <name>Common Gateway Components for Async SDK for SQL API of Azure Cosmos DB Service</name>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-cosmosdb-parent</artifactId>
-  <version>2.6.1-SNAPSHOT</version>
+  <version>2.6.1</version>
   <packaging>pom</packaging>
   <name>Azure Cosmos DB SQL API</name>
   <description>Java Async SDK (with Reactive Extension RX support) for Azure Cosmos DB SQL API</description>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.1</version>
   </parent>
   <artifactId>azure-cosmosdb</artifactId>
   <name>Async SDK for SQL API of Azure Cosmos DB Service</name>


### PR DESCRIPTION
- Multimaster regional failover fixes for query logic ([#245](https://github.com/Azure/azure-cosmosdb-java/commit/104b4a3b30ffd7c8add01096ce6a9b6e7a3f6318))
- jackson-databind 2.9.9.3 update ([#244](https://github.com/Azure/azure-cosmosdb-java/commit/f8e60604d9e2edb0b3bd56ec7909d249de47af50))
- Direct TCP fixes (memory, perf) & metrics interface ([#242](https://github.com/Azure/azure-cosmosdb-java/commit/61562cd16845e2b249a1d91374797faa3469295f))