### PR TITLE
Address memory leak in Direct TCP transport client

### DIFF
--- a/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdContext.java
+++ b/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdContext.java
@@ -148,14 +148,10 @@ public final class RntbdContext {
                 map.put("serverVersion", headers.serverVersion.getValue());
             }
 
-            headers.releaseBuffers();
             throw new RntbdContextException(responseStatus.getStatus(), details, Collections.unmodifiableMap(map));
-
-        } else {
-            RntbdContext context = new RntbdContext(responseStatus, headers);
-            headers.releaseBuffers();
-            return context;
         }
+
+        return new RntbdContext(responseStatus, headers);
     }
 
     public void encode(final ByteBuf out) {
@@ -168,7 +164,7 @@ public final class RntbdContext {
 
         responseStatus.encode(out);
         headers.encode(out);
-        headers.releaseBuffers();
+        headers.release();
 
         final int end = out.writerIndex();
 

--- a/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdContextDecoder.java
+++ b/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdContextDecoder.java
@@ -32,6 +32,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkState;
+import static com.microsoft.azure.cosmosdb.internal.directconnectivity.rntbd.RntbdReporter.reportIssue;
+
 class RntbdContextDecoder extends ByteToMessageDecoder {
 
     private static final Logger logger = LoggerFactory.getLogger(RntbdContextDecoder.class);
@@ -58,6 +61,9 @@ class RntbdContextDecoder extends ByteToMessageDecoder {
                 result = rntbdContext;
             } catch (RntbdContextException error) {
                 context.fireUserEventTriggered(error);
+                result = error;
+            } catch (Throwable error) {
+                context.fireExceptionCaught(error);
                 result = error;
             } finally {
                 in.discardReadBytes();

--- a/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdContextRequestEncoder.java
+++ b/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdContextRequestEncoder.java
@@ -30,46 +30,52 @@ import io.netty.handler.codec.MessageToByteEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class RntbdContextRequestEncoder extends MessageToByteEncoder {
+final class RntbdContextRequestEncoder extends MessageToByteEncoder<RntbdContextRequest> {
 
     private static final Logger Logger = LoggerFactory.getLogger(RntbdContextRequestEncoder.class);
 
     /**
-     * Returns {@code true} if the given message is an @{link RntbdContextRequest} instance
+     * Returns {@code true} if the given message is an {@link RntbdContextRequest} message.
      * <p>
-     * If {@code false} this message should be passed to the next @{link ChannelOutboundHandler} in the pipeline.
+     * If {@code false} this message should be passed to the next {@link io.netty.channel.ChannelHandlerContext} in the
+     * pipeline.
      *
-     * @param message the message to encode
-     * @return @{code true}, if the given message is an an @{link RntbdContextRequest} instance; otherwise @{false}
+     * @param message the message to encode.
+     *
+     * @return {@code true}, if the given message is an an @{link RntbdContextRequest} instance; {@code false}
+     * otherwise.
      */
     @Override
     public boolean acceptOutboundMessage(final Object message) {
-        return message instanceof RntbdContextRequest;
+        return message.getClass() == RntbdContextRequest.class;
     }
 
     /**
-     * Encode an @{link RntbdContextRequest} message into a {@link ByteBuf}
+     * Encode an {@link RntbdContextRequest} message into a {@link ByteBuf}.
      * <p>
      * This method will be called for each written message that can be handled by this encoder.
      *
-     * @param context the {@link ChannelHandlerContext} which this {@link MessageToByteEncoder} belongs to
-     * @param message the message to encode
-     * @param out     the {@link ByteBuf} into which the encoded message will be written
-     * @throws IllegalStateException is thrown if an error occurs
+     * @param context the {@link ChannelHandlerContext} to which this {@link MessageToByteEncoder} belongs.
+     * @param message the message to encode.
+     * @param out the {@link ByteBuf} into which the encoded message will be written.
+     *
+     * @throws IllegalStateException is thrown if an error occurs.
      */
     @Override
-    protected void encode(final ChannelHandlerContext context, final Object message, final ByteBuf out) throws IllegalStateException {
+    protected void encode(
+        final ChannelHandlerContext context,
+        final RntbdContextRequest message,
+        final ByteBuf out) throws IllegalStateException {
 
-        final RntbdContextRequest request = (RntbdContextRequest)message;
         out.markWriterIndex();
 
         try {
-            request.encode(out);
+            message.encode(out);
         } catch (final IllegalStateException error) {
             out.resetWriterIndex();
             throw error;
         }
 
-        Logger.debug("{}: ENCODE COMPLETE: request={}", context.channel(), request);
+        Logger.debug("{}: ENCODE COMPLETE: message={}", context.channel(), message);
     }
 }

--- a/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdResponse.java
+++ b/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdResponse.java
@@ -346,8 +346,7 @@ public final class RntbdResponse implements ReferenceCounted {
 
     StoreResponse toStoreResponse(final RntbdContext context) {
 
-        checkNotNull(context, "context");
-        final int length = this.content.readableBytes();
+        checkNotNull(context, "expected non-null context");
 
         return new StoreResponse(
             this.getStatus().code(),

--- a/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdResponse.java
+++ b/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdResponse.java
@@ -36,6 +36,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.ResourceLeakDetector;
 
@@ -45,18 +46,18 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.microsoft.azure.cosmosdb.internal.directconnectivity.rntbd.RntbdConstants.RntbdResponseHeader;
-import static java.lang.Integer.min;
 
 @JsonPropertyOrder({ "messageLength", "referenceCount", "frame", "headers", "content" })
 public final class RntbdResponse implements ReferenceCounted {
 
     // region Fields
 
-    private static final AtomicIntegerFieldUpdater REFERENCE_COUNT =
-        AtomicIntegerFieldUpdater.newUpdater(RntbdResponse.class, "referenceCount");
+    private static final AtomicIntegerFieldUpdater<RntbdResponse> REFERENCE_COUNT = AtomicIntegerFieldUpdater
+        .newUpdater(RntbdResponse.class, "referenceCount");
 
     @JsonSerialize(using = PayloadSerializer.class)
     private final ByteBuf content;
@@ -79,6 +80,16 @@ public final class RntbdResponse implements ReferenceCounted {
 
     // region Constructors
 
+    /**
+     * Initializes a new {@link RntbdResponse} instance.
+     * <p>
+     * This method is provided for testing purposes only. It should not be used in product code.
+     *
+     * @param activityId an activity ID
+     * @param statusCode a response status code.
+     * @param map a collection of response headers.
+     * @param content a body to be copied to the response.
+     */
     public RntbdResponse(
         final UUID activityId,
         final int statusCode,
@@ -87,7 +98,7 @@ public final class RntbdResponse implements ReferenceCounted {
 
         this.headers = RntbdResponseHeaders.fromMap(map, content.readableBytes() > 0);
         this.message = Unpooled.EMPTY_BUFFER;
-        this.content = content.copy().retain();
+        this.content = content.copy();
 
         final HttpResponseStatus status = HttpResponseStatus.valueOf(statusCode);
         final int length = RntbdResponseStatus.LENGTH + this.headers.computeLength();
@@ -103,12 +114,12 @@ public final class RntbdResponse implements ReferenceCounted {
         final RntbdResponseHeaders headers,
         final ByteBuf content) {
 
-        this.message = message.retain();
+        this.message = message;
         this.referenceCount = 0;
         this.frame = frame;
         this.headers = headers;
-        this.content = content.retain();
-        this.messageLength = message.writerIndex();
+        this.content = content;
+        this.messageLength = message.writerIndex();;
     }
 
     // endregion
@@ -149,6 +160,11 @@ public final class RntbdResponse implements ReferenceCounted {
 
     // region Methods
 
+    /**
+     * Serializes the current {@link RntbdResponse response} to the given {@link ByteBuf byte buffer}.
+     *
+     * @param out the output {@link ByteBuf byte buffer}.
+     */
     public void encode(final ByteBuf out) {
 
         final int start = out.writerIndex();
@@ -167,11 +183,24 @@ public final class RntbdResponse implements ReferenceCounted {
         }
     }
 
+    /**
+     * Returns the value of the given {@link RntbdResponse response} {@link RntbdResponseHeader header}.
+     *
+     * @param header the {@link RntbdResponse response} {@link RntbdResponseHeader header}.
+     * @param <T> the {@link RntbdResponse response} {@link RntbdResponseHeader header} value type.
+     *
+     * @return the value of the given {@code header}.
+     */
     @SuppressWarnings("unchecked")
     public <T> T getHeader(final RntbdResponseHeader header) {
         return (T) this.headers.get(header).getValue();
     }
 
+    /**
+     * Returns {@code true} if this {@link RntbdResponse response} has a payload.
+     *
+     * @return {@code true} if this {@link RntbdResponse response} has a payload; {@code false} otherwise.
+     */
     public boolean hasPayload() {
         return this.headers.isPayloadPresent();
     }
@@ -185,7 +214,9 @@ public final class RntbdResponse implements ReferenceCounted {
     }
 
     /**
-     * Decreases the reference count by {@code 1} and deallocate this response if the count reaches {@code 0}.
+     * Decreases the reference count by {@code 1}.
+     * <p>
+     * The current {@link RntbdResponse response} is deallocated if the count reaches {@code 0}.
      *
      * @return {@code true} if and only if the reference count became {@code 0} and this response is deallocated.
      */
@@ -204,30 +235,23 @@ public final class RntbdResponse implements ReferenceCounted {
     @Override
     public boolean release(final int decrement) {
 
-        return REFERENCE_COUNT.accumulateAndGet(this, decrement, (value, n) -> {
+        checkArgument(decrement > 0, "expected decrement, not %s", decrement);
 
-            value = value - min(value, n);
+        return REFERENCE_COUNT.accumulateAndGet(this, decrement, (referenceCount, decrease) -> {
 
-            if (value == 0) {
+            if (referenceCount < decrement) {
+                throw new IllegalReferenceCountException(referenceCount, -decrease);
+            };
 
-                checkState(this.headers != null && this.content != null);
-                this.headers.releaseBuffers();
+            referenceCount = referenceCount - decrease;
 
-                if (this.message != Unpooled.EMPTY_BUFFER) {
-                    this.message.release();
-                }
-
-                if (this.content != Unpooled.EMPTY_BUFFER) {
-                    this.content.release();
-                }
-
-                // TODO: DANOBLE: figure out why PooledUnsafeDirectByteBuf violates these expectations:
-                //    checkState(this.in == Unpooled.EMPTY_BUFFER || this.in.refCnt() == 0);
-                //    checkState(this.content == Unpooled.EMPTY_BUFFER || this.content.refCnt() == 0);
-                //  Specifically, why are this.in.refCnt() and this.content.refCnt() equal to 1?
+            if (referenceCount == 0) {
+                this.content.release();
+                this.headers.release();
+                this.message.release();
             }
 
-            return value;
+            return referenceCount;
 
         }) == 0;
     }
@@ -236,9 +260,8 @@ public final class RntbdResponse implements ReferenceCounted {
      * Increases the reference count by {@code 1}.
      */
     @Override
-    public ReferenceCounted retain() {
-        REFERENCE_COUNT.incrementAndGet(this);
-        return this;
+    public RntbdResponse retain() {
+        return this.retain(1);
     }
 
     /**
@@ -247,8 +270,19 @@ public final class RntbdResponse implements ReferenceCounted {
      * @param increment amount of the increase
      */
     @Override
-    public ReferenceCounted retain(final int increment) {
-        REFERENCE_COUNT.addAndGet(this, increment);
+    public RntbdResponse retain(final int increment) {
+
+        checkArgument(increment > 0, "expected positive increment, not %s", increment);
+
+        REFERENCE_COUNT.accumulateAndGet(this, increment, (referenceCount, increase) -> {
+            if (referenceCount == 0) {
+                this.content.retain();
+                this.headers.retain();
+                this.message.retain();
+            }
+            return referenceCount + increase;
+        });
+
         return this;
     }
 
@@ -264,7 +298,7 @@ public final class RntbdResponse implements ReferenceCounted {
      * {@link ResourceLeakDetector}.  This method is a shortcut to {@link #touch(Object) touch(null)}.
      */
     @Override
-    public ReferenceCounted touch() {
+    public RntbdResponse touch() {
         return this;
     }
 
@@ -277,7 +311,7 @@ public final class RntbdResponse implements ReferenceCounted {
      * @param hint information useful for debugging (unused)
      */
     @Override
-    public ReferenceCounted touch(final Object hint) {
+    public RntbdResponse touch(final Object hint) {
         return this;
     }
 
@@ -293,7 +327,6 @@ public final class RntbdResponse implements ReferenceCounted {
         if (hasPayload) {
 
             if (!RntbdFramer.canDecodePayload(in)) {
-                headers.releaseBuffers();
                 in.resetReaderIndex();
                 return null;
             }

--- a/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdResponse.java
+++ b/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdResponse.java
@@ -347,12 +347,12 @@ public final class RntbdResponse implements ReferenceCounted {
     StoreResponse toStoreResponse(final RntbdContext context) {
 
         checkNotNull(context, "expected non-null context");
+        final int contentLength = this.content.writerIndex();
 
         return new StoreResponse(
             this.getStatus().code(),
             this.headers.asList(context, this.getActivityId()),
-            length == 0 ? null : this.content.readCharSequence(length, StandardCharsets.UTF_8).toString()
-        );
+            contentLength == 0 ? null : this.content.getCharSequence(0, contentLength, StandardCharsets.UTF_8).toString());
     }
 
     // endregion

--- a/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdResponseDecoder.java
+++ b/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdResponseDecoder.java
@@ -55,8 +55,7 @@ public final class RntbdResponseDecoder extends ByteToMessageDecoder {
             if (response != null) {
                 logger.debug("{} DECODE COMPLETE: {}", context.channel(), response);
                 in.discardReadBytes();
-                response.retain();
-                out.add(response);
+                out.add(response.retain());
             }
         }
     }

--- a/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdTokenStream.java
+++ b/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdTokenStream.java
@@ -132,9 +132,6 @@ abstract class RntbdTokenStream<T extends Enum<T> & RntbdHeader> implements Refe
 
     @Override
     public final boolean release(final int count) {
-//        for (final RntbdToken token : this.tokens.values()) {
-//            token.release(count);
-//        }
         return this.in.release(count);
     }
 
@@ -145,9 +142,6 @@ abstract class RntbdTokenStream<T extends Enum<T> & RntbdHeader> implements Refe
 
     @Override
     public final RntbdTokenStream<T> retain(final int count) {
-//        for (final RntbdToken token : this.tokens.values()) {
-//            token.retain(count);
-//        }
         this.in.retain(count);
         return this;
     }

--- a/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdTokenStream.java
+++ b/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/rntbd/RntbdTokenStream.java
@@ -46,9 +46,9 @@ abstract class RntbdTokenStream<T extends Enum<T> & RntbdHeader> {
 
     RntbdTokenStream(final ImmutableSet<T> headers, final ImmutableMap<Short, T> ids, final ByteBuf in) {
 
-        checkNotNull(headers, "headers");
-        checkNotNull(ids, "ids");
-        checkNotNull(in, "in");
+        checkNotNull(headers, "expected non-null headers");
+        checkNotNull(ids, "expected non-null ids");
+        checkNotNull(in, "expected non-null in");
 
         final Collector<T, ?, ImmutableMap<T, RntbdToken>> collector = Maps.toImmutableEnumMap(h -> h, RntbdToken::create);
         this.tokens = headers.stream().collect(collector);


### PR DESCRIPTION
## Repro
```bash
mkdir azure-cosmos.results
git checkout master
profile=direct
mvn -P$profile -DargLine="-Dio.netty.leakDetectionLevel=paranoid -Dio.netty.leakDetection.targetRecords=255" verify | tee azure-cosmos.results/Verify-P$profile.output
```

### Observe
A number of leaks detections that originate here:
 - **com.microsoft.azure.cosmosdb.internal.directconnectivity.rntbd.RntbdResponse.lambda$release$0(RntbdResponse.java:221)**
- **com.microsoft.azure.cosmosdb.internal.directconnectivity.rntbd.RntbdTokenStream.releaseBuffers(RntbdTokenStream.java:125)**

## Fix
Simplify reference counting implementation by changing the granularity of the instances of `RntbdResponse`, `RntbdToken`, and `RntbdTokenStream`. Specifically,

- Break a response `message` into three pieces as we do today: `frame`, `headers`, and `content`.
- Increment reference counts on `message`, `headers`, and `content` buffers in the first call to `RntbdResponse.retain`.
- Decremeent reference counts on `message`, `headers`, and `content` buffers in a call to to `RntbdResponse.release` when the reference count for the `RntbdResponse` hits zero.
- Do not reference count `RntbdToken` value buffers because this complicates reference counting without need. An `RntbdToken` instance does not have a lifetime outside the `RntbdTokenStream` that owns it.

## Test results

You will see in the before/after test results that this fix eliminates a memory leak in the Direct TCP stack. Performance numbers are provided for comparison with v4 master. There's no indication that performance regressed. There's some evidence in the comparison between v4 fix and v4 master that performance has improved some.

- [Before/After test results](https://github.com/Azure/azure-cosmosdb-java/files/4364507/azure-cosmos-2.6.X.results.tar.gz)

  **Client**
  - East US
  - Standard F16s_v2 (16 vcpus, 32 GiB memory)
  - Linux appserver-lin-3 5.0.0-1032-azure 34-Ubuntu SMP Mon Feb 10 19:37:25 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

  **Cosmos**
  - East US
  - Benchmark database autoscale 500,000 RUs
  - https://cosmos-sdk-core-3.documents.azure.com:443/

  **Script**
```bash
set -o errexit -o nounset

mvn clean install
mkdir -p azure-cosmos.results

for profile in direct e2e emulator examples fast long non-emulator; do
    timeout 55m mvn -P$profile -DargLine="-Dio.netty.leakDetectionLevel=paranoid -Dio.netty.leakDetection.targetRecords=255" verify | tee azure-cosmos.results/Verify-P$profile.output
done
```

- [Performance numbers](https://github.com/Azure/azure-cosmosdb-java/files/4364491/Performance-numbers.xlsx)

  **Client**
  - East US
  - Standard F16s_v2 (16 vcpus, 32 GiB memory)
  - Linux appserver-lin-3 5.0.0-1032-azure 34-Ubuntu SMP Mon Feb 10 19:37:25 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

  **Cosmos**
  - East US
  - Benchmark database autoscale 500,000 RUs
  - https://cosmos-sdk-core-3.documents.azure.com:443/

<img width="1361" alt="image" src="https://user-images.githubusercontent.com/3037615/77267076-ab9adc80-6c5e-11ea-863d-5fbd643376d3.png">

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/3037615/77267140-e3098900-6c5e-11ea-948f-87d7a6a71dd0.png">
