### PR TITLE
Removing H1 to reuse this content in a H2 for docs

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ## 2.6.8 - 2020-05-11
 - Fixes an issue due to which the order by results when resuming from continuation token might contain duplicates/missing documents ([#332](https://github.com/Azure/azure-cosmosdb-java/pull/332))
 


### PR DESCRIPTION
Please see this page: https://docs.microsoft.com/en-us/azure/cosmos-db/sql-api-sdk-async-java it has 2 titles. This PR is to remove the second title.