### PR TITLE
Fix for duplication results by using continuation token

### DIFF
--- a/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/OrderByDocumentQueryExecutionContext.java
+++ b/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/OrderByDocumentQueryExecutionContext.java
@@ -195,7 +195,7 @@ public class OrderByDocumentQueryExecutionContext<T extends Resource>
                     orderByExpressions);
 
             int targetIndex = targetIndexAndFilters.left;
-            targetRangeToOrderByContinuationTokenMap.put(String.valueOf(targetIndex), orderByContinuationToken);
+            targetRangeToOrderByContinuationTokenMap.put(partitionKeyRanges.get(targetIndex).getId(), orderByContinuationToken);
             FormattedFilterInfo formattedFilterInfo = targetIndexAndFilters.right;
 
             // Left

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/QueryValidationTests.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/QueryValidationTests.java
@@ -27,6 +27,7 @@ import com.microsoft.azure.cosmosdb.Document;
 import com.microsoft.azure.cosmosdb.DocumentCollection;
 import com.microsoft.azure.cosmosdb.FeedOptions;
 import com.microsoft.azure.cosmosdb.FeedResponse;
+import com.microsoft.azure.cosmosdb.RequestOptions;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Factory;
@@ -45,7 +46,8 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class QueryValidationTests extends TestSuiteBase {
-    private static final int NUM_DOCUMENTS = 1000;
+    private static final int DEFAULT_NUM_DOCUMENTS = 1000;
+    private static final int DEFAULT_PAGE_SIZE = 100;
     private Random random;
     private Database createdDatabase;
     private DocumentCollection createdCollection;
@@ -66,25 +68,52 @@ public class QueryValidationTests extends TestSuiteBase {
          the results.
          */
         String query = "select * from c order by c.propInt ASC";
-        List<Document> documentsPaged = queryWithContinuationTokens(query, 100);
-
-        List<Document> allDocuments = queryWithContinuationTokens(query, NUM_DOCUMENTS);
-
-        Comparator<Integer> validatorComparator = Comparator.nullsFirst(Comparator.<Integer>naturalOrder());
-        List<String> expectedResourceIds = sortDocumentsAndCollectResourceIds(createdDocuments,
-                                                                              "propInt",
-                                                                              d -> d.getInt("propInt"),
-                                                                              validatorComparator);
-
-        List<String> docIds1 = documentsPaged.stream().map(Document::getId).collect(Collectors.toList());
-        List<String> docIds2 = allDocuments.stream().map(Document::getId).collect(Collectors.toList());
-
-        assertThat(docIds2).containsExactlyInAnyOrderElementsOf(expectedResourceIds);
-        assertThat(docIds1).containsExactlyElementsOf(docIds2);
-
+        queryWithOrderByAndAssert(
+                DEFAULT_PAGE_SIZE,
+                DEFAULT_NUM_DOCUMENTS,
+                query,
+                "propInt",
+                getDefaultCreatedCollectionLink(),
+                createdDocuments);
     }
 
-    private List<Document> queryWithContinuationTokens(String query, int pageSize) {
+    @Test(groups = {"simple"}, timeOut = TIMEOUT)
+    public void orderByQueryForLargeCollection() {
+        RequestOptions requestOptions = new RequestOptions();
+        requestOptions.setOfferThroughput(100000); //want to test scenario with large number physical partitions
+
+        DocumentCollection collection = createCollection(
+                client,
+                SHARED_DATABASE.getId(),
+                getCollectionDefinition(),
+                requestOptions);
+
+        String collectionLink = Utils.getCollectionNameLink(createdDatabase.getId(), collection.getId());
+
+        List<String> partitionKeys = new ArrayList<>();
+        partitionKeys.add((UUID.randomUUID().toString()));
+        partitionKeys.add(UUID.randomUUID().toString());
+
+        List<Document> documentsInserted = this.insertDocuments(
+                DEFAULT_NUM_DOCUMENTS,
+                partitionKeys,
+                collectionLink);
+
+        String query = String.format(
+                "select * from c where c.mypk in ('%s', '%s') order by c.name DESC",
+                partitionKeys.get(0),
+                partitionKeys.get(1));
+
+        queryWithOrderByAndAssert(
+                DEFAULT_PAGE_SIZE,
+                DEFAULT_NUM_DOCUMENTS,
+                query,
+                "name",
+                collectionLink,
+                documentsInserted);
+    }
+
+    private List<Document> queryWithContinuationTokens(String query, int pageSize, String collectionNameLink) {
         logger.info("querying: " + query);
         String requestContinuation = null;
 
@@ -96,7 +125,7 @@ public class QueryValidationTests extends TestSuiteBase {
             options.setEnableCrossPartitionQuery(true);
             options.setMaxDegreeOfParallelism(2);
             options.setRequestContinuation(requestContinuation);
-            Observable<FeedResponse<Document>> queryObservable = client.queryDocuments(getCollectionLink(), query,
+            Observable<FeedResponse<Document>> queryObservable = client.queryDocuments(collectionNameLink, query,
                                                                                        options);
 
             FeedResponse<Document> firstPage = queryObservable.first().toBlocking().single();
@@ -121,37 +150,48 @@ public class QueryValidationTests extends TestSuiteBase {
         createdCollection = SHARED_MULTI_PARTITION_COLLECTION;
         truncateCollection(SHARED_MULTI_PARTITION_COLLECTION);
 
-        List<Document> documentsToInsert = new ArrayList<>();
-
-        for (int i = 0; i < NUM_DOCUMENTS; i++) {
-            documentsToInsert.add(getDocumentDefinition(UUID.randomUUID().toString()));
-        }
-
-
-        createdDocuments = bulkInsertBlocking(client, getCollectionLink(), documentsToInsert);
-
+        createdDocuments = this.insertDocuments(
+                DEFAULT_NUM_DOCUMENTS,
+                null,
+                getDefaultCreatedCollectionLink());
         int numberOfPartitions = client
-                                         .readPartitionKeyRanges(getCollectionLink(), null)
+                                         .readPartitionKeyRanges(getDefaultCreatedCollectionLink(), null)
                                          .flatMap(p -> Observable.from(p.getResults())).toList().toBlocking().single()
                                          .size();
-
-        waitIfNeededForReplicasToCatchUp(this.clientBuilder());
     }
 
-    private Document getDocumentDefinition(String documentId) {
-        String uuid = UUID.randomUUID().toString();
+    private List<Document> insertDocuments(int documentCount, List<String> partitionKeys, String collectionNameLink) {
+        List<Document> documentsToInsert = new ArrayList<>();
+
+        for (int i = 0; i < documentCount; i++) {
+            String partitionKey = partitionKeys == null ?
+                    UUID.randomUUID().toString() :
+                    partitionKeys.get(random.nextInt(partitionKeys.size()));
+
+            documentsToInsert.add(getDocumentDefinition(UUID.randomUUID().toString(), partitionKey));
+        }
+
+        List<Document> documentsInserted = bulkInsertBlocking(client, collectionNameLink, documentsToInsert);
+
+        waitIfNeededForReplicasToCatchUp(this.clientBuilder());
+
+        return documentsInserted;
+    }
+
+    private Document getDocumentDefinition(String documentId, String partitionKey) {
         Document doc = new Document(String.format("{ "
                                                           + "\"id\": \"%s\", "
-                                                          + "\"pkey\": \"%s\", "
+                                                          + "\"mypk\": \"%s\", "
                                                           + "\"propInt\": %s, "
+                                                          + "\"name\": \"test-document\", "
                                                           + "\"sgmts\": [[6519456, 1471916863], [2498434, 1455671440]]"
                                                           + "}"
-                , documentId, uuid, random.nextInt(NUM_DOCUMENTS/2))); 
+                , documentId, partitionKey, random.nextInt(DEFAULT_NUM_DOCUMENTS/2)));
         // Doing NUM_DOCUMENTS/2 just to ensure there will be good number of repetetions.
         return doc;
     }
 
-    public String getCollectionLink() {
+    public String getDefaultCreatedCollectionLink() {
         return Utils.getCollectionNameLink(createdDatabase.getId(), createdCollection.getId());
     }
 
@@ -162,6 +202,29 @@ public class QueryValidationTests extends TestSuiteBase {
                        .filter(d -> d.getHashMap().containsKey(propName)) // removes undefined
                        .sorted((d1, d2) -> comparer.compare(extractProp.apply(d1), extractProp.apply(d2)))
                        .map(d -> d.getId()).collect(Collectors.toList());
+    }
+
+    private void queryWithOrderByAndAssert(
+            int pageSize,
+            int documentCount,
+            String query,
+            String orderByPropName,
+            String collectionLink,
+            List<Document> documentsInserted) {
+        List<Document> documentsPaged = queryWithContinuationTokens(query, pageSize, collectionLink);
+        List<Document> allDocuments = queryWithContinuationTokens(query, documentCount, collectionLink);
+
+        Comparator<Integer> validatorComparator = Comparator.nullsFirst(Comparator.<Integer>naturalOrder());
+        List<String> expectedResourceIds = sortDocumentsAndCollectResourceIds(documentsInserted,
+                orderByPropName,
+                d -> d.getInt(orderByPropName),
+                validatorComparator);
+
+        List<String> docIds1 = documentsPaged.stream().map(Document::getId).collect(Collectors.toList());
+        List<String> docIds2 = allDocuments.stream().map(Document::getId).collect(Collectors.toList());
+
+        assertThat(docIds2).containsExactlyInAnyOrderElementsOf(expectedResourceIds);
+        assertThat(docIds1).containsExactlyElementsOf(docIds2);
     }
 
 }

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/QueryValidationTests.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/QueryValidationTests.java
@@ -113,7 +113,7 @@ public class QueryValidationTests extends TestSuiteBase {
                 documentsInserted);
     }
 
-    private List<Document> queryWithContinuationTokens(String query, int pageSize, String collectionNameLink) {
+    private List<Document> queryWithContinuationTokens(String query, int pageSize, String collectionLink) {
         logger.info("querying: " + query);
         String requestContinuation = null;
 
@@ -125,7 +125,7 @@ public class QueryValidationTests extends TestSuiteBase {
             options.setEnableCrossPartitionQuery(true);
             options.setMaxDegreeOfParallelism(2);
             options.setRequestContinuation(requestContinuation);
-            Observable<FeedResponse<Document>> queryObservable = client.queryDocuments(collectionNameLink, query,
+            Observable<FeedResponse<Document>> queryObservable = client.queryDocuments(collectionLink, query,
                                                                                        options);
 
             FeedResponse<Document> firstPage = queryObservable.first().toBlocking().single();
@@ -155,12 +155,12 @@ public class QueryValidationTests extends TestSuiteBase {
                 null,
                 getDefaultCreatedCollectionLink());
         int numberOfPartitions = client
-                                         .readPartitionKeyRanges(getDefaultCreatedCollectionLink(), null)
-                                         .flatMap(p -> Observable.from(p.getResults())).toList().toBlocking().single()
-                                         .size();
+                                 .readPartitionKeyRanges(getDefaultCreatedCollectionLink(), null)
+                                 .flatMap(p -> Observable.from(p.getResults())).toList().toBlocking().single()
+                                 .size();
     }
 
-    private List<Document> insertDocuments(int documentCount, List<String> partitionKeys, String collectionNameLink) {
+    private List<Document> insertDocuments(int documentCount, List<String> partitionKeys, String collectionLink) {
         List<Document> documentsToInsert = new ArrayList<>();
 
         for (int i = 0; i < documentCount; i++) {
@@ -171,7 +171,7 @@ public class QueryValidationTests extends TestSuiteBase {
             documentsToInsert.add(getDocumentDefinition(UUID.randomUUID().toString(), partitionKey));
         }
 
-        List<Document> documentsInserted = bulkInsertBlocking(client, collectionNameLink, documentsToInsert);
+        List<Document> documentsInserted = bulkInsertBlocking(client, collectionLink, documentsToInsert);
 
         waitIfNeededForReplicasToCatchUp(this.clientBuilder());
 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/QueryValidationTests.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/QueryValidationTests.java
@@ -35,6 +35,7 @@ import org.testng.annotations.Test;
 import rx.Observable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
@@ -90,23 +91,30 @@ public class QueryValidationTests extends TestSuiteBase {
 
         String collectionLink = Utils.getCollectionNameLink(createdDatabase.getId(), collection.getId());
 
-        List<String> partitionKeys = new ArrayList<>();
-        partitionKeys.add((UUID.randomUUID().toString()));
-        partitionKeys.add(UUID.randomUUID().toString());
+        int partitionDocCount = 5;
+        int pageSize = partitionDocCount + 1;
 
-        List<Document> documentsInserted = this.insertDocuments(
-                DEFAULT_NUM_DOCUMENTS,
-                partitionKeys,
-                collectionLink);
+        String partition1Key = UUID.randomUUID().toString();
+        String partition2Key = UUID.randomUUID().toString();
+
+        List<Document> documentsInserted = new ArrayList<>();
+        documentsInserted.addAll(this.insertDocuments(
+                partitionDocCount,
+                Collections.singletonList(partition1Key),
+                collectionLink));
+        documentsInserted.addAll(this.insertDocuments(
+                partitionDocCount,
+                Collections.singletonList(partition2Key),
+                collectionLink));
 
         String query = String.format(
                 "select * from c where c.mypk in ('%s', '%s') order by c.name DESC",
-                partitionKeys.get(0),
-                partitionKeys.get(1));
+                partition1Key,
+                partition2Key);
 
         queryWithOrderByAndAssert(
-                DEFAULT_PAGE_SIZE,
-                DEFAULT_NUM_DOCUMENTS,
+                pageSize,
+                partitionDocCount * 2,
                 query,
                 "name",
                 collectionLink,


### PR DESCRIPTION
Fix issue for duplicate results by using continuation token.

This issue should only happen when some documents has the same order by item value.