### PR TITLE
[BugFix] Fix Header casing of DocumentServiceResponse to be case insensitve header comparison

### DIFF
--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentServiceResponse.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentServiceResponse.java
@@ -52,10 +52,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * This is core Transport/Connection agnostic response for the Azure Cosmos DB database service.
@@ -69,7 +66,8 @@ public class RxDocumentServiceResponse {
         String[] headerNames = response.getResponseHeaderNames();
         String[] headerValues = response.getResponseHeaderValues();
 
-        this.headersMap = new HashMap<>(headerNames.length);
+        // headers in CosmosDB are case insensitive.
+        this.headersMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
         // Gets status code.
         this.statusCode = response.getStatus();

--- a/commons/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentServiceResponseTest.java
+++ b/commons/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentServiceResponseTest.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.azure.cosmosdb.rx.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.microsoft.azure.cosmosdb.internal.directconnectivity.StoreResponse;
+import org.apache.commons.io.IOUtils;
+import org.testng.annotations.Test;
+
+public class RxDocumentServiceResponseTest {
+    @Test(groups = { "unit" })
+    public void headerCasingDocumentServiceResponse() {
+        String content = "I am body";
+        HashMap<String, String> headerMap = new HashMap<>();
+        headerMap.put("key1", "value1");
+        headerMap.put("key2", "value2");
+
+        StoreResponse sp = new StoreResponse(200, new ArrayList<>(headerMap.entrySet()), content);
+        RxDocumentServiceResponse response = new RxDocumentServiceResponse(sp);
+        Map<String, String> headers = response.getResponseHeaders();
+
+        assertThat(headers.get("key1")).isEqualTo("value1");
+        assertThat(headers.get("Key1")).isEqualTo("value1");
+        assertThat(headers.get("KEy1")).isEqualTo("value1");
+        assertThat(headers.get("Key2")).isEqualTo("value2");
+    }
+}


### PR DESCRIPTION
Http Headers are by default case insensitive. Fix DocumentServiceResponse so that the headers coming out of it are case insensitive.