### PR TITLE
Fixing region fail over issue for direct tcp calls

### DIFF
--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/BridgeInternal.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/BridgeInternal.java
@@ -224,6 +224,10 @@ public class BridgeInternal {
         documentClientException.setRequestHeaders(requestHeaders);
     }
 
+    public static void setSubStatusCode(DocumentClientException documentClientException, int subStatusCode) {
+        documentClientException.setSubStatusCode(subStatusCode);
+    }
+
     public static <E extends  DocumentClientException> Map<String, String> getRequestHeaders(DocumentClientException documentClientException) {
         return documentClientException.getRequestHeaders();
     }

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/DocumentClientException.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/DocumentClientException.java
@@ -52,7 +52,7 @@ public class DocumentClientException extends Exception {
 
     private final Map<String, String> requestHeaders;
     private final int statusCode;
-    private volatile Map<String, String> responseHeaders;
+    private Map<String, String> responseHeaders;
 
     private volatile ClientSideRequestStatistics clientSideRequestStatistics;
     private volatile Error error;
@@ -322,10 +322,6 @@ public class DocumentClientException extends Exception {
     }
 
 	void setSubStatusCode(int subStatusCode) {
-		if (this.responseHeaders == null) {
-			this.responseHeaders = new HashMap<>();
-		}
-
 		this.responseHeaders.put(HttpConstants.HttpHeaders.SUB_STATUS, Integer.toString(subStatusCode));
 	}
 

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/DocumentClientException.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/DocumentClientException.java
@@ -51,7 +51,7 @@ public class DocumentClientException extends Exception {
     private static final long serialVersionUID = 1L;
 
     private final Map<String, String> requestHeaders;
-	private final int statusCode;
+    private final int statusCode;
     private volatile Map<String, String> responseHeaders;
 
     private volatile ClientSideRequestStatistics clientSideRequestStatistics;

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/DocumentClientException.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/DocumentClientException.java
@@ -52,7 +52,7 @@ public class DocumentClientException extends Exception {
 
     private final Map<String, String> requestHeaders;
     private final int statusCode;
-    private Map<String, String> responseHeaders;
+    private final Map<String, String> responseHeaders;
 
     private volatile ClientSideRequestStatistics clientSideRequestStatistics;
     private volatile Error error;

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/DocumentClientException.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/DocumentClientException.java
@@ -28,9 +28,9 @@ import com.microsoft.azure.cosmosdb.internal.HttpConstants;
 import com.microsoft.azure.cosmosdb.internal.directconnectivity.Uri;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * This class defines a custom exception type for all operations on
@@ -51,8 +51,8 @@ public class DocumentClientException extends Exception {
     private static final long serialVersionUID = 1L;
 
     private final Map<String, String> requestHeaders;
-    private final Map<String, String> responseHeaders;
-    private final int statusCode;
+	private final int statusCode;
+    private volatile Map<String, String> responseHeaders;
 
     private volatile ClientSideRequestStatistics clientSideRequestStatistics;
     private volatile Error error;
@@ -320,6 +320,14 @@ public class DocumentClientException extends Exception {
                 ", requestHeaders=" + requestHeaders +
                 '}';
     }
+
+	void setSubStatusCode(int subStatusCode) {
+		if (this.responseHeaders == null) {
+			this.responseHeaders = new HashMap<>();
+		}
+
+		this.responseHeaders.put(HttpConstants.HttpHeaders.SUB_STATUS, Integer.toString(subStatusCode));
+	}
 
     String getInnerErrorMessage() {
         String innerErrorMessage = super.getMessage();

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/internal/HttpConstants.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/internal/HttpConstants.java
@@ -323,6 +323,9 @@ public class HttpConstants {
 
         // 404: LSN in session token is higher
         public static final int READ_SESSION_NOT_AVAILABLE = 1002;
+
+        // Client generated gateway network error substatus
+        public static final int GATEWAY_ENDPOINT_UNAVAILABLE = 10001;
     }
 
     public static class HeaderValues {

--- a/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ClientRetryPolicy.java
+++ b/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ClientRetryPolicy.java
@@ -225,24 +225,24 @@ public class ClientRetryPolicy implements IDocumentClientRetryPolicy {
             return Single.just(ShouldRetryResult.noRetry());
         }
 
-		if (!this.canUseMultipleWriteLocations && ! isReadRequest) {
-			// Write requests on single master cannot be retried, no other regions available
-			return Single.just(ShouldRetryResult.noRetry());
-		}
+        if (!this.canUseMultipleWriteLocations && !isReadRequest) {
+            // Write requests on single master cannot be retried, no other regions available
+            return Single.just(ShouldRetryResult.noRetry());
+        }
 
-		int availablePreferredLocations = this.globalEndpointManager.getPreferredLocationCount();
-		if (availablePreferredLocations <= 1) {
-			logger.warn("shouldRetryOnServiceUnavailable() Not retrying. No other regions available for the request. AvailablePreferredLocations = {}", availablePreferredLocations);
-			return Single.just(ShouldRetryResult.noRetry());
-		}
+        int availablePreferredLocations = this.globalEndpointManager.getPreferredLocationCount();
+        if (availablePreferredLocations <= 1) {
+            logger.warn("shouldRetryOnServiceUnavailable() Not retrying. No other regions available for the request. AvailablePreferredLocations = {}", availablePreferredLocations);
+            return Single.just(ShouldRetryResult.noRetry());
+        }
 
-		logger.warn("shouldRetryOnServiceUnavailable() Retrying. Received on endpoint {}, IsReadRequest = {}", this.locationEndpoint, isReadRequest);
+        logger.warn("shouldRetryOnServiceUnavailable() Retrying. Received on endpoint {}, IsReadRequest = {}", this.locationEndpoint, isReadRequest);
 
-		// Retrying on second PreferredLocations
-		// RetryCount is used as zero-based index
-		this.retryContext = new RetryContext(this.serviceUnavailableRetryCount, true);
-		return Single.just(ShouldRetryResult.retryAfter(Duration.ZERO));
-	}
+        // Retrying on second PreferredLocations
+        // RetryCount is used as zero-based index
+        this.retryContext = new RetryContext(this.serviceUnavailableRetryCount, true);
+        return Single.just(ShouldRetryResult.retryAfter(Duration.ZERO));
+    }
 
     private Completable refreshLocation(boolean isReadRequest, boolean forceRefresh) {
         this.failoverRetryCount++;

--- a/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ClientRetryPolicy.java
+++ b/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/ClientRetryPolicy.java
@@ -221,9 +221,9 @@ public class ClientRetryPolicy implements IDocumentClientRetryPolicy {
         }
 
         if (this.serviceUnavailableRetryCount++ > MaxServiceUnavailableRetryCount) {
-			logger.warn("shouldRetryOnBackendServiceUnavailableAsync() Not retrying. Retry count = {}", this.serviceUnavailableRetryCount);
-			return Single.just(ShouldRetryResult.noRetry());
-		}
+            logger.warn("shouldRetryOnBackendServiceUnavailableAsync() Not retrying. Retry count = {}", this.serviceUnavailableRetryCount);
+            return Single.just(ShouldRetryResult.noRetry());
+        }
 
 		if (!this.canUseMultipleWriteLocations && ! isReadRequest) {
 			// Write requests on single master cannot be retried, no other regions available

--- a/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/GlobalEndpointManager.java
+++ b/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/GlobalEndpointManager.java
@@ -29,6 +29,7 @@ import com.microsoft.azure.cosmosdb.DatabaseAccount;
 import com.microsoft.azure.cosmosdb.DatabaseAccountManagerInternal;
 import com.microsoft.azure.cosmosdb.internal.routing.LocationCache;
 import com.microsoft.azure.cosmosdb.rx.internal.routing.LocationHelper;
+import org.apache.commons.collections4.list.UnmodifiableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Completable;
@@ -37,8 +38,6 @@ import rx.Scheduler;
 import rx.Single;
 import rx.functions.Func1;
 import rx.schedulers.Schedulers;
-import org.apache.commons.collections4.list.UnmodifiableList;
-
 
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -48,7 +47,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -149,6 +147,10 @@ public class GlobalEndpointManager implements AutoCloseable {
 
     public boolean CanUseMultipleWriteLocations(RxDocumentServiceRequest request) {
         return this.locationCache.canUseMultipleWriteLocations(request);
+    }
+
+    public int getPreferredLocationCount() {
+        return this.connectionPolicy.getPreferredLocations() != null ? this.connectionPolicy.getPreferredLocations().size() : 0;
     }
 
     public void close() {

--- a/gateway/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/ClientRetryPolicyTest.java
+++ b/gateway/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/ClientRetryPolicyTest.java
@@ -23,9 +23,13 @@
 
 package com.microsoft.azure.cosmosdb.rx.internal;
 
+import com.microsoft.azure.cosmosdb.BridgeInternal;
+import com.microsoft.azure.cosmosdb.DocumentClientException;
 import com.microsoft.azure.cosmosdb.RetryOptions;
+import com.microsoft.azure.cosmosdb.internal.HttpConstants;
 import com.microsoft.azure.cosmosdb.internal.OperationType;
 import com.microsoft.azure.cosmosdb.internal.ResourceType;
+import com.microsoft.azure.cosmosdb.internal.directconnectivity.GoneException;
 import io.netty.handler.timeout.ReadTimeoutException;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
@@ -33,6 +37,8 @@ import rx.Completable;
 import rx.Single;
 import rx.observers.TestSubscriber;
 
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
 import java.net.URL;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -49,6 +55,8 @@ public class ClientRetryPolicyTest {
         ClientRetryPolicy clientRetryPolicy = new ClientRetryPolicy(endpointManager, true, retryOptions);
 
         Exception exception = ReadTimeoutException.INSTANCE;
+        DocumentClientException dce = new DocumentClientException(0,exception);
+        BridgeInternal.setSubStatusCode(dce, HttpConstants.SubStatusCodes.GATEWAY_ENDPOINT_UNAVAILABLE);
 
         RxDocumentServiceRequest dsr = RxDocumentServiceRequest.createFromName(
                 OperationType.Read, "/dbs/db/colls/col/docs/docId", ResourceType.Document);
@@ -57,7 +65,7 @@ public class ClientRetryPolicyTest {
         clientRetryPolicy.onBeforeSendRequest(dsr);
 
         for (int i = 0; i < 10; i++) {
-            Single<IRetryPolicy.ShouldRetryResult> shouldRetry = clientRetryPolicy.shouldRetry(exception);
+            Single<IRetryPolicy.ShouldRetryResult> shouldRetry = clientRetryPolicy.shouldRetry(dce);
 
             validateSuccess(shouldRetry, ShouldRetryValidator.builder()
                     .nullException()
@@ -71,6 +79,47 @@ public class ClientRetryPolicyTest {
     }
 
     @Test(groups = "unit")
+    public void tcpNetworkFailureOnRead() throws Exception {
+        RetryOptions retryOptions = new RetryOptions();
+        GlobalEndpointManager endpointManager = Mockito.mock(GlobalEndpointManager.class);
+        Mockito.doReturn(new URL("http://localhost")).when(endpointManager).resolveServiceEndpoint(Mockito.any(RxDocumentServiceRequest.class));
+        Mockito.doReturn(Completable.complete()).when(endpointManager).refreshLocationAsync(Mockito.eq(null), Mockito.eq(false));
+        Mockito.doReturn(2).when(endpointManager).getPreferredLocationCount();
+        ClientRetryPolicy clientRetryPolicy = new ClientRetryPolicy(endpointManager, true, retryOptions);
+
+        Exception exception = ReadTimeoutException.INSTANCE;
+        GoneException goneException = new GoneException(exception);
+        DocumentClientException dce = new DocumentClientException(HttpConstants.StatusCodes.SERVICE_UNAVAILABLE,
+        goneException);
+
+        RxDocumentServiceRequest dsr = RxDocumentServiceRequest.createFromName(
+        OperationType.Read, "/dbs/db/colls/col/docs/docId", ResourceType.Document);
+        dsr.requestContext = Mockito.mock(DocumentServiceRequestContext.class);
+
+        clientRetryPolicy.onBeforeSendRequest(dsr);
+
+        for (int i = 0; i < 10; i++) {
+            Single<IRetryPolicy.ShouldRetryResult> shouldRetry = clientRetryPolicy.shouldRetry(dce);
+
+            if (i < 2) {
+                validateSuccess(shouldRetry, ShouldRetryValidator.builder()
+                .nullException()
+                .shouldRetry(true)
+                .backOfTime(Duration.ofMillis(0))
+                .build());
+            } else {
+                validateSuccess(shouldRetry, ShouldRetryValidator.builder()
+                .nullException()
+                .shouldRetry(false)
+                .build());
+            }
+
+            Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForRead(Mockito.any());
+            Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForWrite(Mockito.any());
+        }
+    }
+
+    @Test(groups = "unit")
     public void networkFailureOnWrite() throws Exception {
         RetryOptions retryOptions = new RetryOptions();
         GlobalEndpointManager endpointManager = Mockito.mock(GlobalEndpointManager.class);
@@ -79,6 +128,8 @@ public class ClientRetryPolicyTest {
         ClientRetryPolicy clientRetryPolicy = new ClientRetryPolicy(endpointManager, true, retryOptions);
 
         Exception exception = ReadTimeoutException.INSTANCE;
+        DocumentClientException dce = new DocumentClientException(0,exception);
+        BridgeInternal.setSubStatusCode(dce, HttpConstants.SubStatusCodes.GATEWAY_ENDPOINT_UNAVAILABLE);
 
         RxDocumentServiceRequest dsr = RxDocumentServiceRequest.createFromName(
                 OperationType.Create, "/dbs/db/colls/col/docs/docId", ResourceType.Document);
@@ -86,7 +137,7 @@ public class ClientRetryPolicyTest {
 
         clientRetryPolicy.onBeforeSendRequest(dsr);
         for (int i = 0; i < 10; i++) {
-            Single<IRetryPolicy.ShouldRetryResult> shouldRetry = clientRetryPolicy.shouldRetry(exception);
+            Single<IRetryPolicy.ShouldRetryResult> shouldRetry = clientRetryPolicy.shouldRetry(dce);
             //  We don't want to retry writes on network failure
             validateSuccess(shouldRetry, ShouldRetryValidator.builder()
                     .nullException()
@@ -99,6 +150,70 @@ public class ClientRetryPolicyTest {
     }
 
     @Test(groups = "unit")
+    public void tcpNetworkFailureOnWrite() throws Exception {
+        RetryOptions retryOptions = new RetryOptions();
+        GlobalEndpointManager endpointManager = Mockito.mock(GlobalEndpointManager.class);
+        Mockito.doReturn(new URL("http://localhost")).when(endpointManager).resolveServiceEndpoint(Mockito.any(RxDocumentServiceRequest.class));
+        Mockito.doReturn(Completable.complete()).when(endpointManager).refreshLocationAsync(Mockito.eq(null), Mockito.eq(false));
+        Mockito.doReturn(2).when(endpointManager).getPreferredLocationCount();
+        ClientRetryPolicy clientRetryPolicy = new ClientRetryPolicy(endpointManager, true, retryOptions);
+
+        //Non retribale exception for write
+        Exception exception = ReadTimeoutException.INSTANCE;
+        GoneException goneException = new GoneException(exception);
+        DocumentClientException dce = new DocumentClientException(HttpConstants.StatusCodes.SERVICE_UNAVAILABLE,
+        goneException);
+
+        RxDocumentServiceRequest dsr = RxDocumentServiceRequest.createFromName(
+        OperationType.Create, "/dbs/db/colls/col/docs/docId", ResourceType.Document);
+        dsr.requestContext = Mockito.mock(DocumentServiceRequestContext.class);
+
+        clientRetryPolicy.onBeforeSendRequest(dsr);
+
+        for (int i = 0; i < 10; i++) {
+            Single<IRetryPolicy.ShouldRetryResult> shouldRetry = clientRetryPolicy.shouldRetry(dce);
+            //  We don't want to retry writes on network failure with non retriable exception
+            validateSuccess(shouldRetry, ShouldRetryValidator.builder()
+            .nullException()
+            .shouldRetry(false)
+            .build());
+
+            Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForRead(Mockito.any());
+            Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForWrite(Mockito.any());
+        }
+
+        // Retriable exception scenario
+        exception = new SSLHandshakeException("test");
+        goneException = new GoneException(exception);
+        dce = new DocumentClientException(HttpConstants.StatusCodes.SERVICE_UNAVAILABLE,
+        goneException);
+
+        Mockito.doReturn(true).when(endpointManager).CanUseMultipleWriteLocations(Mockito.any(RxDocumentServiceRequest.class));
+        clientRetryPolicy = new ClientRetryPolicy(endpointManager, true, retryOptions);
+        clientRetryPolicy.onBeforeSendRequest(dsr);
+
+        for (int i = 0; i < 10; i++) {
+            Single<IRetryPolicy.ShouldRetryResult> shouldRetry = clientRetryPolicy.shouldRetry(dce);
+            //  We want to retry writes on network failure with retriable exception
+            if (i < 2) {
+                validateSuccess(shouldRetry, ShouldRetryValidator.builder()
+                .nullException()
+                .shouldRetry(true)
+                .backOfTime(Duration.ofMillis(0))
+                .build());
+            } else {
+                validateSuccess(shouldRetry, ShouldRetryValidator.builder()
+                .nullException()
+                .shouldRetry(false)
+                .build());
+            }
+
+            Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForRead(Mockito.any());
+            Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForWrite(Mockito.any());
+        }
+    }
+
+    @Test(groups = "unit")
     public void networkFailureOnUpsert() throws Exception {
         RetryOptions retryOptions = new RetryOptions();
         GlobalEndpointManager endpointManager = Mockito.mock(GlobalEndpointManager.class);
@@ -107,6 +222,8 @@ public class ClientRetryPolicyTest {
         ClientRetryPolicy clientRetryPolicy = new ClientRetryPolicy(endpointManager, true, retryOptions);
 
         Exception exception = ReadTimeoutException.INSTANCE;
+        DocumentClientException dce = new DocumentClientException(0,exception);
+        BridgeInternal.setSubStatusCode(dce, HttpConstants.SubStatusCodes.GATEWAY_ENDPOINT_UNAVAILABLE);
 
         RxDocumentServiceRequest dsr = RxDocumentServiceRequest.createFromName(
             OperationType.Upsert, "/dbs/db/colls/col/docs/docId", ResourceType.Document);
@@ -114,7 +231,7 @@ public class ClientRetryPolicyTest {
 
         clientRetryPolicy.onBeforeSendRequest(dsr);
         for (int i = 0; i < 10; i++) {
-            Single<IRetryPolicy.ShouldRetryResult> shouldRetry = clientRetryPolicy.shouldRetry(exception);
+            Single<IRetryPolicy.ShouldRetryResult> shouldRetry = clientRetryPolicy.shouldRetry(dce);
             //  We don't want to retry writes on network failure
             validateSuccess(shouldRetry, ShouldRetryValidator.builder()
                                                              .nullException()
@@ -127,6 +244,39 @@ public class ClientRetryPolicyTest {
     }
 
     @Test(groups = "unit")
+    public void tcpNetworkFailureOnUpsert() throws Exception {
+        RetryOptions retryOptions = new RetryOptions();
+        GlobalEndpointManager endpointManager = Mockito.mock(GlobalEndpointManager.class);
+        Mockito.doReturn(new URL("http://localhost")).when(endpointManager).resolveServiceEndpoint(Mockito.any(RxDocumentServiceRequest.class));
+        Mockito.doReturn(Completable.complete()).when(endpointManager).refreshLocationAsync(Mockito.eq(null), Mockito.eq(false));
+        Mockito.doReturn(2).when(endpointManager).getPreferredLocationCount();
+        ClientRetryPolicy clientRetryPolicy = new ClientRetryPolicy(endpointManager, true, retryOptions);
+
+        Exception exception = ReadTimeoutException.INSTANCE;
+        GoneException goneException = new GoneException(exception);
+        DocumentClientException dce = new DocumentClientException(HttpConstants.StatusCodes.SERVICE_UNAVAILABLE,
+        goneException);
+
+        RxDocumentServiceRequest dsr = RxDocumentServiceRequest.createFromName(
+        OperationType.Upsert, "/dbs/db/colls/col/docs/docId", ResourceType.Document);
+        dsr.requestContext = Mockito.mock(DocumentServiceRequestContext.class);
+
+        clientRetryPolicy.onBeforeSendRequest(dsr);
+
+        for (int i = 0; i < 10; i++) {
+            Single<IRetryPolicy.ShouldRetryResult> shouldRetry = clientRetryPolicy.shouldRetry(dce);
+            //  We don't want to retry writes on network failure with non retriable exception
+            validateSuccess(shouldRetry, ShouldRetryValidator.builder()
+            .nullException()
+            .shouldRetry(false)
+            .build());
+
+            Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForRead(Mockito.any());
+            Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForWrite(Mockito.any());
+        }
+    }
+
+    @Test(groups = "unit")
     public void networkFailureOnDelete() throws Exception {
         RetryOptions retryOptions = new RetryOptions();
         GlobalEndpointManager endpointManager = Mockito.mock(GlobalEndpointManager.class);
@@ -135,6 +285,8 @@ public class ClientRetryPolicyTest {
         ClientRetryPolicy clientRetryPolicy = new ClientRetryPolicy(endpointManager, true, retryOptions);
 
         Exception exception = ReadTimeoutException.INSTANCE;
+        DocumentClientException dce = new DocumentClientException(0,exception);
+        BridgeInternal.setSubStatusCode(dce, HttpConstants.SubStatusCodes.GATEWAY_ENDPOINT_UNAVAILABLE);
 
         RxDocumentServiceRequest dsr = RxDocumentServiceRequest.createFromName(
             OperationType.Delete, "/dbs/db/colls/col/docs/docId", ResourceType.Document);
@@ -142,7 +294,7 @@ public class ClientRetryPolicyTest {
 
         clientRetryPolicy.onBeforeSendRequest(dsr);
         for (int i = 0; i < 10; i++) {
-            Single<IRetryPolicy.ShouldRetryResult> shouldRetry = clientRetryPolicy.shouldRetry(exception);
+            Single<IRetryPolicy.ShouldRetryResult> shouldRetry = clientRetryPolicy.shouldRetry(dce);
             //  We don't want to retry writes on network failure
             validateSuccess(shouldRetry, ShouldRetryValidator.builder()
                                                              .nullException()
@@ -151,6 +303,39 @@ public class ClientRetryPolicyTest {
 
             Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForRead(Mockito.any());
             Mockito.verify(endpointManager, Mockito.times(i + 1)).markEndpointUnavailableForWrite(Mockito.any());
+        }
+    }
+
+    @Test(groups = "unit")
+    public void tcpNetworkFailureOnDelete() throws Exception {
+        RetryOptions retryOptions = new RetryOptions();
+        GlobalEndpointManager endpointManager = Mockito.mock(GlobalEndpointManager.class);
+        Mockito.doReturn(new URL("http://localhost")).when(endpointManager).resolveServiceEndpoint(Mockito.any(RxDocumentServiceRequest.class));
+        Mockito.doReturn(Completable.complete()).when(endpointManager).refreshLocationAsync(Mockito.eq(null), Mockito.eq(false));
+        Mockito.doReturn(2).when(endpointManager).getPreferredLocationCount();
+        ClientRetryPolicy clientRetryPolicy = new ClientRetryPolicy(endpointManager, true, retryOptions);
+
+        Exception exception = ReadTimeoutException.INSTANCE;
+        GoneException goneException = new GoneException(exception);
+        DocumentClientException dce = new DocumentClientException(HttpConstants.StatusCodes.SERVICE_UNAVAILABLE,
+        goneException);
+
+        RxDocumentServiceRequest dsr = RxDocumentServiceRequest.createFromName(
+        OperationType.Delete, "/dbs/db/colls/col/docs/docId", ResourceType.Document);
+        dsr.requestContext = Mockito.mock(DocumentServiceRequestContext.class);
+
+        clientRetryPolicy.onBeforeSendRequest(dsr);
+
+        for (int i = 0; i < 10; i++) {
+            Single<IRetryPolicy.ShouldRetryResult> shouldRetry = clientRetryPolicy.shouldRetry(dce);
+            //  We don't want to retry writes on network failure with non retriable exception
+            validateSuccess(shouldRetry, ShouldRetryValidator.builder()
+            .nullException()
+            .shouldRetry(false)
+            .build());
+
+            Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForRead(Mockito.any());
+            Mockito.verify(endpointManager, Mockito.times(0)).markEndpointUnavailableForWrite(Mockito.any());
         }
     }
 

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/CollectionCrudTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/CollectionCrudTest.java
@@ -255,7 +255,7 @@ public class CollectionCrudTest extends TestSuiteBase {
 
         // validate
         ResourceResponseValidator<DocumentCollection> validator = new ResourceResponseValidator.Builder<DocumentCollection>()
-                .indexingMode(IndexingMode.Lazy).build();
+                .indexingMode(IndexingMode.Consistent).build();
         validateSuccess(readObservable, validator);
         safeDeleteAllCollections(client, database);
     }
@@ -283,7 +283,7 @@ public class CollectionCrudTest extends TestSuiteBase {
             null).toBlocking().single().getResource();
 
         //  sanity check
-        assertThat(readCollection.getIndexingPolicy().getIndexingMode()).isEqualTo(IndexingMode.Lazy);
+        assertThat(readCollection.getIndexingPolicy().getIndexingMode()).isEqualTo(IndexingMode.Consistent);
 
         Integer timeToLive = 120;
         collection.setDefaultTimeToLive(timeToLive);
@@ -291,7 +291,7 @@ public class CollectionCrudTest extends TestSuiteBase {
         DocumentCollection replacedCollection = client.replaceCollection(collection,
             null).toBlocking().single().getResource();
 
-        assertThat(readCollection.getIndexingPolicy().getIndexingMode()).isEqualTo(IndexingMode.Lazy);
+        assertThat(readCollection.getIndexingPolicy().getIndexingMode()).isEqualTo(IndexingMode.Consistent);
 
         assertThat(replacedCollection.getDefaultTimeToLive()).isEqualTo(timeToLive);
 


### PR DESCRIPTION
Currently for tcp network exception we are doing region failover, which is causing problem for some users where due to some intermittent network issue on BE nodes sdk is sending traffic for next 5 min to other available region.

This PR will limit the region failover only in case of http network failure.
