### PR TITLE
Converting lazy index check to consistent index in test class

### DIFF
--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/CollectionCrudTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/CollectionCrudTest.java
@@ -255,7 +255,7 @@ public class CollectionCrudTest extends TestSuiteBase {
 
         // validate
         ResourceResponseValidator<DocumentCollection> validator = new ResourceResponseValidator.Builder<DocumentCollection>()
-                .indexingMode(IndexingMode.Lazy).build();
+                .indexingMode(IndexingMode.Consistent).build();
         validateSuccess(readObservable, validator);
         safeDeleteAllCollections(client, database);
     }
@@ -283,7 +283,7 @@ public class CollectionCrudTest extends TestSuiteBase {
             null).toBlocking().single().getResource();
 
         //  sanity check
-        assertThat(readCollection.getIndexingPolicy().getIndexingMode()).isEqualTo(IndexingMode.Lazy);
+        assertThat(readCollection.getIndexingPolicy().getIndexingMode()).isEqualTo(IndexingMode.Consistent);
 
         Integer timeToLive = 120;
         collection.setDefaultTimeToLive(timeToLive);
@@ -291,7 +291,7 @@ public class CollectionCrudTest extends TestSuiteBase {
         DocumentCollection replacedCollection = client.replaceCollection(collection,
             null).toBlocking().single().getResource();
 
-        assertThat(readCollection.getIndexingPolicy().getIndexingMode()).isEqualTo(IndexingMode.Lazy);
+        assertThat(readCollection.getIndexingPolicy().getIndexingMode()).isEqualTo(IndexingMode.Consistent);
 
         assertThat(replacedCollection.getDefaultTimeToLive()).isEqualTo(timeToLive);
 


### PR DESCRIPTION
Sdk master branch test cases are failing as now BE service does not support lazy indexing.
Fixing the test case in this PR