### PR TITLE
Improving http request time out avoiding region failover for high latency request

### DIFF
--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/ClientSideRequestStatistics.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/ClientSideRequestStatistics.java
@@ -123,7 +123,7 @@ public class ClientSideRequestStatistics {
         AddressResolutionStatistics resolutionStatistics = new AddressResolutionStatistics();
         resolutionStatistics.startTime = ZonedDateTime.now(ZoneOffset.UTC);
         //  Very far in the future
-        resolutionStatistics.endTime = ZonedDateTime.of(LocalDateTime.MAX, ZoneOffset.UTC);
+        resolutionStatistics.endTime = null;
         resolutionStatistics.targetEndpoint = targetEndpoint == null ? "<NULL>" : targetEndpoint.toString();
 
         synchronized (this) {

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/ClientSideRequestStatistics.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/ClientSideRequestStatistics.java
@@ -22,6 +22,13 @@
  */
 package com.microsoft.azure.cosmosdb;
 
+import com.microsoft.azure.cosmosdb.internal.OperationType;
+import com.microsoft.azure.cosmosdb.internal.ResourceType;
+import com.microsoft.azure.cosmosdb.internal.Utils;
+import com.microsoft.azure.cosmosdb.internal.directconnectivity.StoreResult;
+import com.microsoft.azure.cosmosdb.rx.internal.RxDocumentServiceRequest;
+import org.apache.commons.lang3.StringUtils;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
@@ -36,13 +43,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-
-import com.microsoft.azure.cosmosdb.internal.OperationType;
-import com.microsoft.azure.cosmosdb.internal.ResourceType;
-import com.microsoft.azure.cosmosdb.internal.Utils;
-import com.microsoft.azure.cosmosdb.internal.directconnectivity.StoreResult;
-import com.microsoft.azure.cosmosdb.rx.internal.RxDocumentServiceRequest;
-import org.apache.commons.lang3.StringUtils;
 
 public class ClientSideRequestStatistics {
 
@@ -133,7 +133,7 @@ public class ClientSideRequestStatistics {
         return identifier;
     }
 
-    public void recordAddressResolutionEnd(String identifier) {
+    public void recordAddressResolutionEnd(String identifier, String errorMessage) {
         if (StringUtils.isEmpty(identifier)) {
             return;
         }
@@ -150,6 +150,8 @@ public class ClientSideRequestStatistics {
 
             AddressResolutionStatistics resolutionStatistics = this.addressResolutionStatistics.get(identifier);
             resolutionStatistics.endTime = responseTime;
+            resolutionStatistics.errorMessage = errorMessage;
+            resolutionStatistics.inflightRequest = false;
         }
     }
 
@@ -259,6 +261,8 @@ public class ClientSideRequestStatistics {
         private ZonedDateTime startTime;
         private ZonedDateTime endTime;
         private String targetEndpoint;
+        private String errorMessage;
+        private boolean inflightRequest = true;
 
         AddressResolutionStatistics() {
         }
@@ -266,10 +270,12 @@ public class ClientSideRequestStatistics {
         @Override
         public String toString() {
             return "AddressResolutionStatistics{" +
-                    "startTime=\"" + formatDateTime(startTime) + "\"" +
-                    ", endTime=\"" + formatDateTime(endTime) + "\"" +
-                    ", targetEndpoint='" + targetEndpoint + '\'' +
-                    '}';
+            "startTime=\"" + formatDateTime(startTime) + "\"" +
+            ", endTime=\"" + formatDateTime(endTime) + "\"" +
+            ", inflightRequest='" + inflightRequest + '\'' +
+            ", targetEndpoint='" + targetEndpoint + '\'' +
+            ", errorMessage='" + errorMessage + '\'' +
+            '}';
         }
     }
 }

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/ClientSideRequestStatistics.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/ClientSideRequestStatistics.java
@@ -32,7 +32,6 @@ import org.apache.commons.lang3.StringUtils;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
-import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -262,6 +261,10 @@ public class ClientSideRequestStatistics {
         private ZonedDateTime endTime;
         private String targetEndpoint;
         private String errorMessage;
+
+        // If one replica return error we start address call in parallel,
+        // on other replica  valid response, we end the current user request,
+        // indicating background addressResolution is still inflight
         private boolean inflightRequest = true;
 
         AddressResolutionStatistics() {

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/HttpClientFactory.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/HttpClientFactory.java
@@ -23,6 +23,7 @@
 
 package com.microsoft.azure.cosmosdb.rx.internal;
 
+import com.microsoft.azure.cosmosdb.internal.Constants;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelPipeline;
@@ -30,9 +31,7 @@ import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.proxy.HttpProxyHandler;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.handler.ssl.SslProvider;
 import io.reactivex.netty.pipeline.PipelineConfigurator;
 import io.reactivex.netty.pipeline.PipelineConfiguratorComposite;
 import io.reactivex.netty.pipeline.ssl.SSLEngineFactory;
@@ -41,15 +40,9 @@ import io.reactivex.netty.protocol.http.HttpObjectAggregationConfigurator;
 import io.reactivex.netty.protocol.http.client.CompositeHttpClientBuilder;
 import io.reactivex.netty.protocol.http.client.HttpClient.HttpClientConfig;
 import io.reactivex.netty.protocol.http.client.HttpClientPipelineConfigurator;
-import io.reactivex.netty.protocol.http.client.HttpClientRequest;
-import io.reactivex.netty.protocol.http.client.HttpClientResponse;
-
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLException;
-
-import com.microsoft.azure.cosmosdb.internal.Constants;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLEngine;
 import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
@@ -58,6 +51,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class HttpClientFactory {
     private final static String NETWORK_LOG_CATEGORY = "com.microsoft.azure.cosmosdb.netty-network";
+    private final static int MINIMUM_HTTP_REQUEST_TIMEOUT_IN_MILLIS = 60 * 1000;
 
     private final Configs configs;
     private Integer maxPoolSize;
@@ -85,7 +79,7 @@ public class HttpClientFactory {
     }
 
     public HttpClientFactory withRequestTimeoutInMillis(int requestTimeoutInMillis) {
-        this.requestTimeoutInMillis = requestTimeoutInMillis;
+        this.requestTimeoutInMillis = requestTimeoutInMillis < MINIMUM_HTTP_REQUEST_TIMEOUT_IN_MILLIS ? MINIMUM_HTTP_REQUEST_TIMEOUT_IN_MILLIS : requestTimeoutInMillis;
         return this;
     }
 

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentServiceRequest.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/RxDocumentServiceRequest.java
@@ -101,7 +101,8 @@ public class RxDocumentServiceRequest {
                 || this.operationType == OperationType.Head
                 || this.operationType == OperationType.HeadFeed
                 || this.operationType == OperationType.Query
-                || this.operationType == OperationType.SqlQuery;
+                || this.operationType == OperationType.SqlQuery
+                || this.operationType == OperationType.QueryPlan;
     }
 
     public boolean isReadOnlyScript() {

--- a/commons/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/HttpClientFactoryTest.java
+++ b/commons/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/HttpClientFactoryTest.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.azure.cosmosdb.rx.internal;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.protocol.http.client.CompositeHttpClientBuilder;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.testng.annotations.Test;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+public class HttpClientFactoryTest {
+
+	@Test(groups = "unit")
+	public void withRequestTimeoutInMillis() throws IllegalAccessException {
+		HttpClientFactory clientFactory = new HttpClientFactory(new Configs())
+		.withRequestTimeoutInMillis(10*1000);
+		int requestTimeoutInMillis = (int)FieldUtils.readField(clientFactory, "requestTimeoutInMillis", true);;
+		assertThat(requestTimeoutInMillis).isEqualTo(60*1000);
+
+		clientFactory = new HttpClientFactory(new Configs())
+		.withRequestTimeoutInMillis(61*1000);
+		requestTimeoutInMillis = (int)FieldUtils.readField(clientFactory, "requestTimeoutInMillis", true);;
+		assertThat(requestTimeoutInMillis).isEqualTo(61*1000);
+	}
+}

--- a/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/GatewayAddressCache.java
+++ b/direct-impl/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/GatewayAddressCache.java
@@ -337,10 +337,11 @@ public class GatewayAddressCache implements IAddressCache {
             if (logger.isDebugEnabled()) {
                 logger.debug("getServerAddressesViaGatewayAsync deserializes result");
             }
-            logAddressResolutionEnd(request, identifier);
+            logAddressResolutionEnd(request, identifier, null);
             List<Address> addresses = dsr.getQueryResponse(Address.class);
             return addresses;
         }).onErrorResumeNext(throwable -> {
+            logAddressResolutionEnd(request, identifier, throwable.toString());
             if (!(throwable instanceof Exception)) {
                 // fatal error
                 logger.error("Unexpected failure {}", throwable.getMessage(), throwable);
@@ -538,11 +539,35 @@ public class GatewayAddressCache implements IAddressCache {
         Single<RxDocumentServiceResponse> dsrObs = responseObs.toSingle().flatMap(rsp ->
                 HttpClientUtils.parseResponseAsync(rsp));
         return dsrObs.map(
-                dsr -> {
-                    logAddressResolutionEnd(request, identifier);
-                    List<Address> addresses = dsr.getQueryResponse(Address.class);
-                    return addresses;
-                });
+        dsr -> {
+            logAddressResolutionEnd(request, identifier, null);
+            List<Address> addresses = dsr.getQueryResponse(Address.class);
+            return addresses;
+        }).onErrorResumeNext(throwable -> {
+            logAddressResolutionEnd(request, identifier, throwable.toString());
+            if (!(throwable instanceof Exception)) {
+                // fatal error
+                logger.error("Unexpected failure {}", throwable.getMessage(), throwable);
+                return Single.error(throwable);
+            }
+
+            Exception exception = (Exception) throwable;
+            DocumentClientException dce;
+            if (!(exception instanceof DocumentClientException)) {
+                // wrap in DocumentClientException
+                logger.error("Network failure", exception);
+                dce = new DocumentClientException(0, exception);
+                BridgeInternal.setRequestHeaders(dce, request.getHeaders());
+            } else {
+                dce = (DocumentClientException) exception;
+            }
+
+            if (WebExceptionUtility.isNetworkFailure(dce)) {
+                BridgeInternal.setSubStatusCode(dce, HttpConstants.SubStatusCodes.GATEWAY_ENDPOINT_UNAVAILABLE);
+            }
+
+            return Single.error(dce);
+        });
     }
 
     private Pair<PartitionKeyRangeIdentity, AddressInformation[]> toPartitionAddressAndRange(String collectionRid, List<Address> addresses) {
@@ -623,9 +648,9 @@ public class GatewayAddressCache implements IAddressCache {
         return null;
     }
 
-    private static void logAddressResolutionEnd(RxDocumentServiceRequest request, String identifier) {
+    private static void logAddressResolutionEnd(RxDocumentServiceRequest request, String identifier, String errorMessage) {
         if (request.requestContext.clientSideRequestStatistics != null) {
-            request.requestContext.clientSideRequestStatistics.recordAddressResolutionEnd(identifier);
+            request.requestContext.clientSideRequestStatistics.recordAddressResolutionEnd(identifier, errorMessage);
         }
     }
 }

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/HttpRequestTimeoutTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/HttpRequestTimeoutTest.java
@@ -47,7 +47,6 @@ import static org.assertj.core.api.Assertions.fail;
 
 public class HttpRequestTimeoutTest extends TestSuiteBase {
 
-
 	@Test(groups = {"emulator"}, timeOut = TIMEOUT)
 	public void clientInitialization() {
 		AsyncDocumentClient client = null;

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/HttpRequestTimeoutTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/HttpRequestTimeoutTest.java
@@ -68,7 +68,7 @@ public class HttpRequestTimeoutTest extends TestSuiteBase {
 	}
 
 	@Test(groups = {"emulator"}, timeOut = TIMEOUT)
-	public void DocumentWrite() {
+	public void documentWrite() {
 		AsyncDocumentClient client = null;
 		try {
 			ConnectionPolicy connectionPolicy = new ConnectionPolicy();
@@ -124,7 +124,7 @@ public class HttpRequestTimeoutTest extends TestSuiteBase {
 	}
 
 	@Test(groups = {"emulator"}, timeOut = TIMEOUT)
-	public void DocumentRead() {
+	public void documentRead() {
 		AsyncDocumentClient client = null;
 		try {
 			ConnectionPolicy connectionPolicy = new ConnectionPolicy();
@@ -185,7 +185,7 @@ public class HttpRequestTimeoutTest extends TestSuiteBase {
 	}
 
 	@Test(groups = {"emulator"}, timeOut = TIMEOUT)
-	public void DocumentQuery() {
+	public void documentQuery() {
 		AsyncDocumentClient client = null;
 		try {
 			ConnectionPolicy connectionPolicy = new ConnectionPolicy();
@@ -240,9 +240,7 @@ public class HttpRequestTimeoutTest extends TestSuiteBase {
 			queryObservable = client.queryDocuments(SHARED_MULTI_PARTITION_COLLECTION.getSelfLink(), "Select * from C", feedOptions);
 			FailureValidator failureValidator = new FailureValidator.Builder().causeInstanceOf(ClosedChannelException.class).build();
 			validateQueryFailure(queryObservable, failureValidator);
-			// TODO https://github.com/Azure/azure-cosmosdb-java/issues/359
-			// After above fix, below check should be on markEndpointUnavailableForRead
-			Mockito.verify(spyGlobalEndpointManager, Mockito.times(0)).markEndpointUnavailableForWrite(Matchers.any(URL.class));
+			Mockito.verify(spyGlobalEndpointManager, Mockito.times(1)).markEndpointUnavailableForRead(Matchers.any(URL.class));
 		} catch (Exception ex) {
 			fail("Should not throw exception in the test" + ex.getMessage());
 		} finally {

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/HttpRequestTimeoutTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/HttpRequestTimeoutTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.azure.cosmosdb.rx.internal;
+
+import com.microsoft.azure.cosmosdb.ConnectionPolicy;
+import com.microsoft.azure.cosmosdb.Document;
+import com.microsoft.azure.cosmosdb.FeedOptions;
+import com.microsoft.azure.cosmosdb.FeedResponse;
+import com.microsoft.azure.cosmosdb.PartitionKey;
+import com.microsoft.azure.cosmosdb.RequestOptions;
+import com.microsoft.azure.cosmosdb.ResourceResponse;
+import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
+import com.microsoft.azure.cosmosdb.rx.FailureValidator;
+import com.microsoft.azure.cosmosdb.rx.FeedResponseListValidator;
+import com.microsoft.azure.cosmosdb.rx.FeedResponseValidator;
+import com.microsoft.azure.cosmosdb.rx.ResourceResponseValidator;
+import com.microsoft.azure.cosmosdb.rx.TestConfigurations;
+import com.microsoft.azure.cosmosdb.rx.TestSuiteBase;
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.protocol.http.client.CompositeHttpClient;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+import rx.Observable;
+
+import java.net.URL;
+import java.nio.channels.ClosedChannelException;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.fail;
+
+public class HttpRequestTimeoutTest extends TestSuiteBase {
+
+
+	@Test(groups = {"emulator"}, timeOut = TIMEOUT)
+	public void clientInitialization() {
+		AsyncDocumentClient client = null;
+		try {
+			ConnectionPolicy connectionPolicy = new ConnectionPolicy();
+			connectionPolicy.setRequestTimeoutInMillis(1); //Very low time, forcing it to fail
+			client = new AsyncDocumentClient.Builder()
+			.withConnectionPolicy(connectionPolicy)
+			.withMasterKeyOrResourceToken(TestConfigurations.MASTER_KEY)
+			.withServiceEndpoint(TestConfigurations.HOST)
+			.build();
+		} catch (Exception ex) {
+			fail("Client initialization should not fail due to low requestTimeout on connection policy " + ex.getMessage());
+		} finally {
+			if (client != null) {
+				client.close();
+			}
+		}
+	}
+
+	@Test(groups = {"emulator"}, timeOut = TIMEOUT)
+	public void DocumentWrite() {
+		AsyncDocumentClient client = null;
+		try {
+			ConnectionPolicy connectionPolicy = new ConnectionPolicy();
+			client = new AsyncDocumentClient.Builder()
+			.withConnectionPolicy(connectionPolicy)
+			.withMasterKeyOrResourceToken(TestConfigurations.MASTER_KEY)
+			.withServiceEndpoint(TestConfigurations.HOST)
+			.build();
+
+			RetryPolicy retryPolicy = (RetryPolicy) FieldUtils.readField(client, "retryPolicy", true);
+			GlobalEndpointManager globalEndpointManager = (GlobalEndpointManager) FieldUtils.readField(retryPolicy, "globalEndpointManager", true);
+			GlobalEndpointManager spyGlobalEndpointManager = Mockito.spy(globalEndpointManager);
+			FieldUtils.writeField(retryPolicy, "globalEndpointManager", spyGlobalEndpointManager, true);
+
+			HttpClientFactory httpClientFactory = new HttpClientFactory(new Configs());
+			httpClientFactory.withRequestTimeoutInMillis(1);
+			CompositeHttpClient<ByteBuf, ByteBuf> httpClient = httpClientFactory.toHttpClientBuilder().build();
+
+			//  Scenario after restricting http readTimeout i.e.verifying success and no region fail over as httpClientFactory.withRequestTimeoutInMillis(1)
+			// should not lower the timeout below 60 sec
+			RxGatewayStoreModel storeModel = (RxGatewayStoreModel) FieldUtils.readField(client, "gatewayProxy", true);
+			FieldUtils.writeField(storeModel, "httpClient", httpClient, true);
+			Document successDocument = new Document();
+			successDocument.setId(UUID.randomUUID().toString());
+			successDocument.set("mypk", successDocument.getId());
+			Observable<ResourceResponse<Document>> readObservable = client.createDocument(SHARED_MULTI_PARTITION_COLLECTION.getSelfLink(), successDocument, new RequestOptions(), true);
+			ResourceResponseValidator<Document> successValidator = new ResourceResponseValidator.Builder<Document>()
+			.withId(successDocument.getId())
+			.build();
+			validateSuccess(readObservable, successValidator);
+			Mockito.verify(spyGlobalEndpointManager, Mockito.times(0)).markEndpointUnavailableForWrite(Matchers.any(URL.class));
+
+			// Scenario before restricting http readTimeout i.e. verifying failure by updating requestTimeoutInMillis via reflection
+			// we should see the request failure and region fail over
+			httpClientFactory.withRequestTimeoutInMillis(1);
+			FieldUtils.writeField(httpClientFactory, "requestTimeoutInMillis", 1, true);
+			httpClient = httpClientFactory.toHttpClientBuilder().build();
+			FieldUtils.writeField(storeModel, "httpClient", httpClient, true);
+			Document failureDocument = new Document();
+			failureDocument.setId(UUID.randomUUID().toString());
+			failureDocument.set("mypk", successDocument.getId());
+			readObservable = client.createDocument(SHARED_MULTI_PARTITION_COLLECTION.getSelfLink(), failureDocument, new RequestOptions(), true);
+			FailureValidator failureValidator = new FailureValidator.Builder().causeInstanceOf(ClosedChannelException.class).build();
+			validateFailure(readObservable, failureValidator);
+			Mockito.verify(spyGlobalEndpointManager, Mockito.times(1)).markEndpointUnavailableForWrite(Matchers.any(URL.class));
+		} catch (Exception ex) {
+			fail("Should not throw exception in the test" + ex.getMessage());
+		} finally {
+			if (client != null) {
+				client.close();
+			}
+		}
+	}
+
+	@Test(groups = {"emulator"}, timeOut = TIMEOUT)
+	public void DocumentRead() {
+		AsyncDocumentClient client = null;
+		try {
+			ConnectionPolicy connectionPolicy = new ConnectionPolicy();
+			client = new AsyncDocumentClient.Builder()
+			.withConnectionPolicy(connectionPolicy)
+			.withMasterKeyOrResourceToken(TestConfigurations.MASTER_KEY)
+			.withServiceEndpoint(TestConfigurations.HOST)
+			.build();
+
+			//Creating document for read
+			Document document = new Document();
+			document.setId(UUID.randomUUID().toString());
+			document.set("mypk", document.getId());
+			RequestOptions options = new RequestOptions();
+			options.setPartitionKey(new PartitionKey(document.getId()));
+			document = client.createDocument(SHARED_MULTI_PARTITION_COLLECTION.getSelfLink(), document, options, true)
+			.toBlocking()
+			.first()
+			.getResource();
+
+			RetryPolicy retryPolicy = (RetryPolicy) FieldUtils.readField(client, "retryPolicy", true);
+			GlobalEndpointManager globalEndpointManager = (GlobalEndpointManager) FieldUtils.readField(retryPolicy, "globalEndpointManager", true);
+			GlobalEndpointManager spyGlobalEndpointManager = Mockito.spy(globalEndpointManager);
+			FieldUtils.writeField(retryPolicy, "globalEndpointManager", spyGlobalEndpointManager, true);
+
+			HttpClientFactory httpClientFactory = new HttpClientFactory(new Configs());
+			httpClientFactory.withRequestTimeoutInMillis(1);
+			CompositeHttpClient<ByteBuf, ByteBuf> httpClient = httpClientFactory.toHttpClientBuilder().build();
+
+			// Scenario after restricting http readTimeout i.e.verifying success and no region fail over as httpClientFactory.withRequestTimeoutInMillis(1)
+			// should not lower the timeout below 60 sec
+			RxGatewayStoreModel storeModel = (RxGatewayStoreModel) FieldUtils.readField(client, "gatewayProxy", true);
+			FieldUtils.writeField(storeModel, "httpClient", httpClient, true);
+			Observable<ResourceResponse<Document>> readObservable = client.readDocument(document.getSelfLink(), options);
+			ResourceResponseValidator<Document> successValidator = new ResourceResponseValidator.Builder<Document>()
+			.withId(document.getId())
+			.build();
+			validateSuccess(readObservable, successValidator);
+			Mockito.verify(spyGlobalEndpointManager, Mockito.times(0)).markEndpointUnavailableForRead(Matchers.any(URL.class));
+
+			// Scenario before restricting http readTimeout i.e. verifying failure by updating requestTimeoutInMillis via reflection
+			// we should see the request failure and region fail over
+			httpClientFactory.withRequestTimeoutInMillis(1);
+			FieldUtils.writeField(httpClientFactory, "requestTimeoutInMillis", 1, true);
+			httpClient = httpClientFactory.toHttpClientBuilder().build();
+			FieldUtils.writeField(storeModel, "httpClient", httpClient, true);
+			readObservable = readObservable = client.readDocument(document.getSelfLink(), options);
+			FailureValidator failureValidator = new FailureValidator.Builder().causeInstanceOf(ClosedChannelException.class).build();
+			validateFailure(readObservable, failureValidator);
+			Mockito.verify(spyGlobalEndpointManager, Mockito.times(1)).markEndpointUnavailableForRead(Matchers.any(URL.class));
+		} catch (Exception ex) {
+			fail("Should not throw exception in the test" + ex.getMessage());
+		} finally {
+			if (client != null) {
+				client.close();
+			}
+		}
+	}
+
+	@Test(groups = {"emulator"}, timeOut = TIMEOUT)
+	public void DocumentQuery() {
+		AsyncDocumentClient client = null;
+		try {
+			ConnectionPolicy connectionPolicy = new ConnectionPolicy();
+			client = new AsyncDocumentClient.Builder()
+			.withConnectionPolicy(connectionPolicy)
+			.withMasterKeyOrResourceToken(TestConfigurations.MASTER_KEY)
+			.withServiceEndpoint(TestConfigurations.HOST)
+			.build();
+
+			//Creating document for read
+			Document document = new Document();
+			document.setId(UUID.randomUUID().toString());
+			document.set("mypk", document.getId());
+			RequestOptions options = new RequestOptions();
+			options.setPartitionKey(new PartitionKey(document.getId()));
+			document = client.createDocument(SHARED_MULTI_PARTITION_COLLECTION.getSelfLink(), document, options, true)
+			.toBlocking()
+			.first()
+			.getResource();
+
+			RetryPolicy retryPolicy = (RetryPolicy) FieldUtils.readField(client, "retryPolicy", true);
+			GlobalEndpointManager globalEndpointManager = (GlobalEndpointManager) FieldUtils.readField(retryPolicy, "globalEndpointManager", true);
+			GlobalEndpointManager spyGlobalEndpointManager = Mockito.spy(globalEndpointManager);
+			FieldUtils.writeField(retryPolicy, "globalEndpointManager", spyGlobalEndpointManager, true);
+
+			HttpClientFactory httpClientFactory = new HttpClientFactory(new Configs());
+			httpClientFactory.withRequestTimeoutInMillis(1);
+			CompositeHttpClient<ByteBuf, ByteBuf> httpClient = httpClientFactory.toHttpClientBuilder().build();
+
+			// Scenario after restricting http readTimeout i.e.verifying success and no region fail over as httpClientFactory.withRequestTimeoutInMillis(1)
+			// should not lower the timeout below 60 sec
+			RxGatewayStoreModel storeModel = (RxGatewayStoreModel) FieldUtils.readField(client, "gatewayProxy", true);
+			FieldUtils.writeField(storeModel, "httpClient", httpClient, true);
+			FeedOptions feedOptions = new FeedOptions();
+			feedOptions.setPartitionKey(new PartitionKey(document.getId()));
+			Observable<FeedResponse<Document>> queryObservable = client.queryDocuments(SHARED_MULTI_PARTITION_COLLECTION.getSelfLink(), "Select * from C", feedOptions);
+			FeedResponseListValidator<Document> validator = new FeedResponseListValidator.Builder<Document>()
+			.totalSize(1)
+			.numberOfPages(1)
+			.pageSatisfy(0, new FeedResponseValidator.Builder<Document>()
+			.requestChargeGreaterThanOrEqualTo(1.0).build())
+			.build();
+			validateQuerySuccess(queryObservable, validator, FEED_TIMEOUT);
+			Mockito.verify(spyGlobalEndpointManager, Mockito.times(0)).markEndpointUnavailableForWrite(Matchers.any(URL.class));
+
+			// Scenario before restricting http readTimeout i.e. verifying failure by updating requestTimeoutInMillis via reflection
+			// we should see the request failure and region fail over
+			httpClientFactory.withRequestTimeoutInMillis(1);
+			FieldUtils.writeField(httpClientFactory, "requestTimeoutInMillis", 1, true);
+			httpClient = httpClientFactory.toHttpClientBuilder().build();
+			FieldUtils.writeField(storeModel, "httpClient", httpClient, true);
+			queryObservable = client.queryDocuments(SHARED_MULTI_PARTITION_COLLECTION.getSelfLink(), "Select * from C", feedOptions);
+			FailureValidator failureValidator = new FailureValidator.Builder().causeInstanceOf(ClosedChannelException.class).build();
+			validateQueryFailure(queryObservable, failureValidator);
+			// TODO https://github.com/Azure/azure-cosmosdb-java/issues/359
+			// After above fix, below check should be on markEndpointUnavailableForRead
+			Mockito.verify(spyGlobalEndpointManager, Mockito.times(0)).markEndpointUnavailableForWrite(Matchers.any(URL.class));
+		} catch (Exception ex) {
+			fail("Should not throw exception in the test" + ex.getMessage());
+		} finally {
+			if (client != null) {
+				client.close();
+			}
+		}
+	}
+}

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/HttpRequestTimeoutTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/HttpRequestTimeoutTest.java
@@ -1,20 +1,25 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
-
 package com.microsoft.azure.cosmosdb.rx.internal;
 
 import com.microsoft.azure.cosmosdb.ConnectionPolicy;

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/directconnectivity/ClientSideRequestStatisticsTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/directconnectivity/ClientSideRequestStatisticsTest.java
@@ -70,7 +70,7 @@ public class ClientSideRequestStatisticsTest extends TestSuiteBase {
 			//Success address resolution client side statistics
 			assertThat(writeResourceResponse.getClientSideRequestStatistics().toString()).contains("AddressResolutionStatistics");
 			assertThat(writeResourceResponse.getClientSideRequestStatistics().toString()).contains("inflightRequest='false'");
-			assertThat(writeResourceResponse.getClientSideRequestStatistics().toString()).doesNotContain("31 Dec +999999999 23:59:59.999");
+			assertThat(writeResourceResponse.getClientSideRequestStatistics().toString()).doesNotContain("endTime=\"null\"");
 			assertThat(writeResourceResponse.getClientSideRequestStatistics().toString()).contains("errorMessage='null'");
 			assertThat(writeResourceResponse.getClientSideRequestStatistics().toString()).doesNotContain("errorMessage='java.nio.channels.ClosedChannelException");
 
@@ -108,7 +108,7 @@ public class ClientSideRequestStatisticsTest extends TestSuiteBase {
 			//Partial success address resolution client side statistics
 			assertThat(readResourceResponse.getClientSideRequestStatistics().toString()).contains("AddressResolutionStatistics");
 			assertThat(readResourceResponse.getClientSideRequestStatistics().toString()).contains("inflightRequest='false'");
-			assertThat(readResourceResponse.getClientSideRequestStatistics().toString()).doesNotContain("31 Dec +999999999 23:59:59.999");
+			assertThat(readResourceResponse.getClientSideRequestStatistics().toString()).doesNotContain("endTime=\"null\"");
 			assertThat(readResourceResponse.getClientSideRequestStatistics().toString()).contains("errorMessage='null'");
 			assertThat(readResourceResponse.getClientSideRequestStatistics().toString()).contains("errorMessage='java.nio.channels.ClosedChannelException");
 		} catch (Exception ex) {

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/directconnectivity/ClientSideRequestStatisticsTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/directconnectivity/ClientSideRequestStatisticsTest.java
@@ -1,0 +1,122 @@
+/*
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.microsoft.azure.cosmosdb.rx.internal.directconnectivity;
+
+import com.microsoft.azure.cosmosdb.ConnectionMode;
+import com.microsoft.azure.cosmosdb.ConnectionPolicy;
+import com.microsoft.azure.cosmosdb.Document;
+import com.microsoft.azure.cosmosdb.PartitionKey;
+import com.microsoft.azure.cosmosdb.RequestOptions;
+import com.microsoft.azure.cosmosdb.ResourceResponse;
+import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient;
+import com.microsoft.azure.cosmosdb.rx.TestConfigurations;
+import com.microsoft.azure.cosmosdb.rx.TestSuiteBase;
+import com.microsoft.azure.cosmosdb.rx.internal.Configs;
+import com.microsoft.azure.cosmosdb.rx.internal.HttpClientFactory;
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.protocol.http.client.CompositeHttpClient;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.testng.annotations.Test;
+
+import java.net.URL;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class ClientSideRequestStatisticsTest extends TestSuiteBase {
+
+	@Test(groups = {"emulator"}, timeOut = TIMEOUT)
+	public void AddressResolutionStatistics() {
+		AsyncDocumentClient client = null;
+		try {
+			ConnectionPolicy connectionPolicy = new ConnectionPolicy();
+			connectionPolicy.setConnectionMode(ConnectionMode.Direct);
+			client = new AsyncDocumentClient.Builder()
+			.withConnectionPolicy(connectionPolicy)
+			.withMasterKeyOrResourceToken(TestConfigurations.MASTER_KEY)
+			.withServiceEndpoint(TestConfigurations.HOST)
+			.build();
+			Document document = new Document();
+			document.setId(UUID.randomUUID().toString());
+			document.set("mypk", document.getId());
+			RequestOptions options = new RequestOptions();
+			options.setPartitionKey(new PartitionKey(document.getId()));
+			ResourceResponse<Document> writeResourceResponse = client.createDocument(SHARED_MULTI_PARTITION_COLLECTION.getSelfLink(), document, options, true)
+			.toBlocking()
+			.first();
+			//Success address resolution client side statistics
+			assertThat(writeResourceResponse.getClientSideRequestStatistics().toString()).contains("AddressResolutionStatistics");
+			assertThat(writeResourceResponse.getClientSideRequestStatistics().toString()).contains("inflightRequest='false'");
+			assertThat(writeResourceResponse.getClientSideRequestStatistics().toString()).doesNotContain("31 Dec +999999999 23:59:59.999");
+			assertThat(writeResourceResponse.getClientSideRequestStatistics().toString()).contains("errorMessage='null'");
+			assertThat(writeResourceResponse.getClientSideRequestStatistics().toString()).doesNotContain("errorMessage='java.nio.channels.ClosedChannelException");
+
+			client = new AsyncDocumentClient.Builder()
+			.withConnectionPolicy(connectionPolicy)
+			.withMasterKeyOrResourceToken(TestConfigurations.MASTER_KEY)
+			.withServiceEndpoint(TestConfigurations.HOST)
+			.build();
+
+			GlobalAddressResolver addressResolver = (GlobalAddressResolver) FieldUtils.readField(client, "addressResolver", true);
+			Map<URL, GlobalAddressResolver.EndpointCache> addressCacheByEndpoint = (Map<URL, GlobalAddressResolver.EndpointCache>) FieldUtils.readField(addressResolver, "addressCacheByEndpoint",
+			true);
+			GlobalAddressResolver.EndpointCache endpointCache = (GlobalAddressResolver.EndpointCache) addressCacheByEndpoint.values().toArray()[0];
+
+			HttpClientFactory httpClientFactory = new HttpClientFactory(new Configs());
+			httpClientFactory.withRequestTimeoutInMillis(1);
+			FieldUtils.writeField(httpClientFactory, "requestTimeoutInMillis", 1, true);
+			CompositeHttpClient<ByteBuf, ByteBuf> httpClient = httpClientFactory.toHttpClientBuilder().build();
+			FieldUtils.writeField(endpointCache.addressCache, "httpClient", httpClient, true);
+
+			new Thread(() -> {
+				try {
+					Thread.sleep(5000);
+					HttpClientFactory httpClientFactory1 = new HttpClientFactory(new Configs());
+					CompositeHttpClient<ByteBuf, ByteBuf> httpClient1 = httpClientFactory1.toHttpClientBuilder().build();
+					FieldUtils.writeField(endpointCache.addressCache, "httpClient", httpClient1, true);
+				} catch (Exception e) {
+					fail(e.getMessage());
+				}
+			}).start();
+			ResourceResponse<Document> readResourceResponse = client.readDocument(writeResourceResponse.getResource().getSelfLink(), options)
+			.toBlocking()
+			.first();
+
+			//Partial success address resolution client side statistics
+			assertThat(readResourceResponse.getClientSideRequestStatistics().toString()).contains("AddressResolutionStatistics");
+			assertThat(readResourceResponse.getClientSideRequestStatistics().toString()).contains("inflightRequest='false'");
+			assertThat(readResourceResponse.getClientSideRequestStatistics().toString()).doesNotContain("31 Dec +999999999 23:59:59.999");
+			assertThat(readResourceResponse.getClientSideRequestStatistics().toString()).contains("errorMessage='null'");
+			assertThat(readResourceResponse.getClientSideRequestStatistics().toString()).contains("errorMessage='java.nio.channels.ClosedChannelException");
+		} catch (Exception ex) {
+			fail("Client initialization should not fail due to low requestTimeout on connection policy " + ex.getMessage());
+		} finally {
+			if (client != null) {
+				client.close();
+			}
+		}
+	}
+}

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/directconnectivity/ClientSideRequestStatisticsTest.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/internal/directconnectivity/ClientSideRequestStatisticsTest.java
@@ -49,7 +49,7 @@ import static org.assertj.core.api.Assertions.fail;
 public class ClientSideRequestStatisticsTest extends TestSuiteBase {
 
 	@Test(groups = {"emulator"}, timeOut = TIMEOUT)
-	public void AddressResolutionStatistics() {
+	public void addressResolutionStatistics() {
 		AsyncDocumentClient client = null;
 		try {
 			ConnectionPolicy connectionPolicy = new ConnectionPolicy();


### PR DESCRIPTION
Currently we have an api on ConnectionPolicy setRequestTimeoutInMillis which sets the request time out for both TCP and HTTP requests.
We want to cap the lower value of http client request time out to 60 sec, as http network request call ends up into region fail over and also Gateway does not have any sla.

**Note:** This PR also contains the improvement on AddressResolutionStatistics in ClientSideRequestStatistics, which include error message if there is any failure on address cache refresh call, also including flag inflightRequest which will indicate whether address call finished in lifetime of the the request.

**Also closes query plan issue**
closes https://github.com/Azure/azure-cosmosdb-java/issues/359