### PR TITLE
Removed generic IO exception condition in network failure. Replaced with specific exceptions. Included in unit testing

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,4 @@
 #   https://help.github.com/articles/about-codeowners/  
 
 # Default owner for repo
-*	@moderakh @christopheranderson @kushagraThapar @David-Noble-at-work
+*	@moderakh @kushagraThapar @FabianMeiswinkel @kirankumarkolli @mbhaskar @simplynaveen20 @xinlian12 @milismsft

--- a/direct-impl/src/test/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/WebExceptionUtilityTest.java
+++ b/direct-impl/src/test/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/WebExceptionUtilityTest.java
@@ -23,6 +23,7 @@
 
 package com.microsoft.azure.cosmosdb.internal.directconnectivity;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.handler.timeout.ReadTimeoutException;
@@ -30,12 +31,20 @@ import io.reactivex.netty.client.PoolExhaustedException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
+import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.net.ConnectException;
+import java.net.HttpRetryException;
 import java.net.NoRouteToHostException;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.net.UnknownServiceException;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.InterruptedByTimeoutException;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -124,6 +133,33 @@ public class WebExceptionUtilityTest {
                 },
                 {
                         new ChannelException(), true
+                },
+                {
+                        new IOException(), false
+                },
+                {
+                        new ClosedChannelException(), true
+                },
+                {
+                        new SocketException(), true
+                },
+                {
+                        new SSLException("dummy"), true
+                },
+                {
+                        new UnknownServiceException(), true
+                },
+                {
+                        new HttpRetryException("dummy", 500), true
+                },
+                {
+                        new InterruptedByTimeoutException(), true
+                },
+                {
+                        new InterruptedIOException(), true
+                },
+                {
+                        new JsonMappingException(null, "dummy"), false
                 }
         };
     }

--- a/gateway/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/WebExceptionUtility.java
+++ b/gateway/src/main/java/com/microsoft/azure/cosmosdb/internal/directconnectivity/WebExceptionUtility.java
@@ -27,12 +27,19 @@ import com.microsoft.azure.cosmosdb.rx.internal.Utils;
 import io.netty.channel.ChannelException;
 import io.reactivex.netty.client.PoolExhaustedException;
 
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.net.ConnectException;
+import java.net.HttpRetryException;
 import java.net.NoRouteToHostException;
+import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.net.UnknownServiceException;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.InterruptedByTimeoutException;
 
 public class WebExceptionUtility {
     public static boolean isWebExceptionRetriable(Exception ex) {
@@ -88,7 +95,19 @@ public class WebExceptionUtility {
     }
 
     private static boolean isNetworkFailureInternal(Exception ex) {
-        if (ex instanceof IOException) {
+        //  We have seen these cases in CRIs
+        if (ex instanceof ClosedChannelException
+            || ex instanceof SocketException
+            || ex instanceof SSLException
+            || ex instanceof UnknownHostException) {
+            return true;
+        }
+
+        //  These cases might be related, but we haven't seen them ever
+        if (ex instanceof UnknownServiceException
+            || ex instanceof HttpRetryException
+            || ex instanceof InterruptedByTimeoutException
+            || ex instanceof InterruptedIOException) {
             return true;
         }
 


### PR DESCRIPTION
* Removed generic IO exception condition in network failure. Replaced with specific exceptions. Included in unit testing.
* This is a direct port of PR - https://github.com/Azure/azure-sdk-for-java/pull/16469