### PR TITLE
Clarify ConnectionPolicy multi write region configs

### DIFF
--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/ConnectionPolicy.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/ConnectionPolicy.java
@@ -315,8 +315,12 @@ public final class ConnectionPolicy {
      * to true has no effect until EnableMultipleWriteLocations in DatabaseAccount
      * is also set to true.
      *
-     * Default value is false indicating that writes are only directed to
-     * first region in PreferredLocations property.
+     * Default value is false indicating that writes are directed to
+     * first region in PreferredLocations property or the primary account region if no PreferredLocations are specified. 
+     *
+     * The value should match your account configuration.
+     * 
+     * During the client lifetime, writes can change regional endpoint in the case of any event described at https://docs.microsoft.com/azure/cosmos-db/troubleshoot-sdk-availability
      *
      * @param usingMultipleWriteLocations flag to enable writes on any locations (regions) for geo-replicated database accounts.
      */

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/ConnectionPolicy.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/ConnectionPolicy.java
@@ -278,7 +278,7 @@ public final class ConnectionPolicy {
      * is also set to true.
      *
      * Default value is false indicating that writes are directed to
-     * first region in PreferredLocations property or the primary account region if no PreferredLocations are specified. 
+     * first region in PreferredLocations property if it's a write region or the primary account region if no PreferredLocations are specified. 
      *
      * The value should match your account configuration.
      * 
@@ -316,7 +316,7 @@ public final class ConnectionPolicy {
      * is also set to true.
      *
      * Default value is false indicating that writes are directed to
-     * first region in PreferredLocations property or the primary account region if no PreferredLocations are specified. 
+     * first region in PreferredLocations property if it's a write region or the primary account region if no PreferredLocations are specified. 
      *
      * The value should match your account configuration.
      * 

--- a/commons/src/main/java/com/microsoft/azure/cosmosdb/ConnectionPolicy.java
+++ b/commons/src/main/java/com/microsoft/azure/cosmosdb/ConnectionPolicy.java
@@ -277,8 +277,12 @@ public final class ConnectionPolicy {
      * to true has no effect until EnableMultipleWriteLocations in DatabaseAccount
      * is also set to true.
      *
-     * Default value is false indicating that writes are only directed to
-     * first region in PreferredLocations property.
+     * Default value is false indicating that writes are directed to
+     * first region in PreferredLocations property or the primary account region if no PreferredLocations are specified. 
+     *
+     * The value should match your account configuration.
+     * 
+     * During the client lifetime, writes can change regional endpoint in the case of any event described at https://docs.microsoft.com/azure/cosmos-db/troubleshoot-sdk-availability
      *
      * @return flag to enable writes on any locations (regions) for geo-replicated database accounts.
      */


### PR DESCRIPTION
Current texts imply that write requests will "only" be directed to the first preferred location.