### PR TITLE
Fixing the response header 'x-ms-continuation' value issue.

### DIFF
--- a/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/TopDocumentQueryExecutionContext.java
+++ b/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/TopDocumentQueryExecutionContext.java
@@ -127,9 +127,14 @@ public class TopDocumentQueryExecutionContext<T extends Resource> implements IDo
                     if (top != collectedItems) {
                         // Add Take Continuation Token
                         String sourceContinuationToken = t.getResponseContinuation();
-                        TakeContinuationToken takeContinuationToken = new TakeContinuationToken(top - collectedItems,
-                                sourceContinuationToken);
-                        headers.put(HttpConstants.HttpHeaders.CONTINUATION, takeContinuationToken.toJson());
+                        if (sourceContinuationToken != null) {
+                            TakeContinuationToken takeContinuationToken = new TakeContinuationToken(top - collectedItems,
+                                    sourceContinuationToken);
+                            headers.put(HttpConstants.HttpHeaders.CONTINUATION, takeContinuationToken.toJson());
+                        } else {
+                            // Null out the continuation token
+                            headers.put(HttpConstants.HttpHeaders.CONTINUATION, null);
+                        }
                     } else {
                         // Null out the continuation token
                         headers.put(HttpConstants.HttpHeaders.CONTINUATION, null);

--- a/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/TopDocumentQueryExecutionContext.java
+++ b/gateway/src/main/java/com/microsoft/azure/cosmosdb/rx/internal/query/TopDocumentQueryExecutionContext.java
@@ -132,7 +132,8 @@ public class TopDocumentQueryExecutionContext<T extends Resource> implements IDo
                                     sourceContinuationToken);
                             headers.put(HttpConstants.HttpHeaders.CONTINUATION, takeContinuationToken.toJson());
                         } else {
-                            // Null out the continuation token
+                            // Null out the continuation token. The sourceContinuationToken being null means
+                            // that this is the last page and there are no more elements left to fetch.
                             headers.put(HttpConstants.HttpHeaders.CONTINUATION, null);
                         }
                     } else {

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TopQueryTests.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TopQueryTests.java
@@ -143,6 +143,12 @@ public class TopQueryTests extends TestSuiteBase {
         this.queryWithContinuationTokensAndPageSizes(query, new int[] { 1, 5, 10 }, 8);
     }
 
+    @Test(groups = { "simple" }, timeOut = TIMEOUT * 1000, retryAnalyzer = RetryAnalyzer.class)
+    public void queryDocumentsWithTopGreaterThanItemsContinuationTokens() throws Exception {
+        String query = "SELECT TOP 40 * FROM c";
+        this.queryWithContinuationTokensAndPageSizes(query, new int[] {1}, 20);
+    }
+
     private void queryWithContinuationTokensAndPageSizes(String query, int[] pageSizes, int topCount) {
         for (int pageSize : pageSizes) {
             List<Document> receivedDocuments = this.queryWithContinuationTokens(query, pageSize);

--- a/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TopQueryTests.java
+++ b/sdk/src/test/java/com/microsoft/azure/cosmosdb/rx/TopQueryTests.java
@@ -145,7 +145,7 @@ public class TopQueryTests extends TestSuiteBase {
 
     @Test(groups = { "simple" }, timeOut = TIMEOUT * 1000, retryAnalyzer = RetryAnalyzer.class)
     public void queryDocumentsWithTopGreaterThanItemsContinuationTokens() throws Exception {
-        String query = "SELECT TOP 40 * FROM c";
+        String query = "SELECT TOP 2147483647 * FROM c";
         this.queryWithContinuationTokensAndPageSizes(query, new int[] {1}, 20);
     }
 


### PR DESCRIPTION
1. The issue is happening when using the top query to get the top of 'x'  items where 'x' is greater than the total number of items in the database.
2. Link for the ICM - https://portal.microsofticm.com/imp/v3/incidents/details/286671765/home 
